### PR TITLE
chore: GitHub Actions の各 action を Node.js 24 対応版にアップデート

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,22 +30,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "yarn"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./docs"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Closes #38

## Summary
GitHub Actions ランナーの Node.js 20 廃止スケジュールに対応するため、`.github/workflows/static.yml` で使用中の 5 つの action をすべて Node.js 24 対応版にアップデート。

- **2026-06-02**: Node.js 24 がデフォルト化（強制移行）
- **2026-09-16**: Node.js 20 がランナーから完全削除

## アップデート内容

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `node-version` (ビルド環境) | "20" | **"22"** (active LTS) |

## Breaking changes の事前確認

| Action | 確認事項 | 影響 |
|---|---|---|
| `setup-node@v5` | `packageManager` フィールドベースの自動キャッシュ導入 | ⭕ 既存の `cache: "yarn"` 明示指定があるため挙動変化なし |
| `setup-node@v6` | 自動キャッシュを npm 限定化 | ⭕ 明示指定が引き続き有効 |
| `upload-pages-artifact@v4` | dotfiles をデフォルト除外 | ⭕ `docs/` 配下に dotfiles 無し |
| `checkout@v5/v6` | Node 24 化、creds 永続化方式の変更 | ⭕ 単純な checkout 用途のみで影響なし |
| `configure-pages@v6` / `deploy-pages@v5` | Node 24 化のみ、機能変更なし | ⭕ |

## Test plan
- [x] release notes の breaking changes 全件レビュー済
- [x] yarn の明示キャッシュ指定が setup-node v6 で引き続き機能することを確認
- [ ] **マージ後の CI run で deprecation 警告が消えること & デプロイが成功すること** (本ワークフローは push to main / workflow_dispatch でしか動かないため PR 上で事前検証不可)

## ロールバック手順
万一マージ後の CI が失敗した場合、各 action を旧バージョン (v4/v5/v3) に戻すだけで復旧可能。`yarn.lock` 等プロダクションコードには変更なし。

## 関連
- Issue #38: GitHub Actions の Node.js 20 廃止対応