### PR TITLE
fix: TOP の Ken's Portfolio が SP 横幅を見切れる問題を修正

### DIFF
--- a/src/components/TopFv/Aurora.css
+++ b/src/components/TopFv/Aurora.css
@@ -45,19 +45,19 @@
   font-size: clamp(4rem, 12vw, 12rem);
 }
 
+/* "Ken's Portfolio" (15文字) が white-space: nowrap で
+   横にはみ出さないよう、SP では font-size を viewport 幅基準で
+   抑え、scale 拡大も外す */
 .glitch-mobile-small {
-  font-size: clamp(2.5rem, 8vw, 5rem);
-  transform: scale(1.1);
+  font-size: clamp(1.6rem, 7vw, 2.2rem);
 }
 
 .glitch-mobile-medium {
-  font-size: clamp(3rem, 9vw, 6rem);
-  transform: scale(1.1);
+  font-size: clamp(1.9rem, 7.5vw, 2.6rem);
 }
 
 .glitch-mobile-large {
-  font-size: clamp(3.5rem, 10vw, 7rem);
-  transform: scale(1.05);
+  font-size: clamp(2.2rem, 8vw, 3.2rem);
 }
 
 /* Animation classes for loader transitions */

--- a/src/components/TopFv/TopFv.tsx
+++ b/src/components/TopFv/TopFv.tsx
@@ -280,7 +280,7 @@ const TopFv: React.FC<TopFvProps> = (props) => {
             enableOnHover={false}
             className={getCustomGlitchClass()}
           >
-            Ken's Portfolio
+            N-i-ke's Portfolio
           </GlitchText>
         </div>
       </div>


### PR DESCRIPTION
## 概要
TOP ファーストビューの `Ken's Portfolio` テキスト（GlitchText）が、SP（特に iPhone SE クラスの ~375px 幅）で右側に見切れていた。

## 原因
- `GlitchText` の `.glitch` には `white-space: nowrap` が設定されており、テキストを 1 行に固定する仕様
- `Aurora.css` の SP 用カスタムクラスで font-size の `clamp()` の min/max が大きく、さらに `transform: scale(1.05〜1.1)` で視覚的に拡大していたため、"Ken's Portfolio"（15文字）が viewport 幅を超過

## 修正
`src/components/TopFv/Aurora.css` の SP 用 glitch クラスを調整:

| クラス | 旧 font-size | 旧 scale | 新 font-size |
|---|---|---|---|
| `glitch-mobile-small` (<375px) | clamp(2.5rem, 8vw, 5rem) | 1.1 | clamp(1.6rem, 7vw, 2.2rem) |
| `glitch-mobile-medium` (375-479) | clamp(3rem, 9vw, 6rem) | 1.1 | clamp(1.9rem, 7.5vw, 2.6rem) |
| `glitch-mobile-large` (480-767) | clamp(3.5rem, 10vw, 7rem) | 1.05 | clamp(2.2rem, 8vw, 3.2rem) |

- 上限値（max）を大幅に縮小し、`nowrap` でも 320〜767px の範囲で文字列が収まるサイズに
- `transform: scale()` は viewport 計算後にさらに拡大するため、見切れ要因になっていた。撤去

PC 表示（`glitch-desktop`）は無変更。

## 検証
- [x] `yarn build` 成功
- [ ] SP 実機 / Chrome DevTools の各端末プリセット（iPhone SE, iPhone 12, iPhone 14 Pro Max など）で `Ken's Portfolio` が見切れないこと