### PR TITLE
feat: MySkills のアイコン表示を reactbits.dev の LogoLoop に置き換え

### DIFF
--- a/src/components/LogoLoop/LogoLoop.css
+++ b/src/components/LogoLoop/LogoLoop.css
@@ -1,0 +1,185 @@
+.logoloop {
+  position: relative;
+  overflow-x: hidden;
+
+  --logoloop-gap: 32px;
+  --logoloop-logoHeight: 28px;
+  --logoloop-fadeColorAuto: #ffffff;
+}
+
+.logoloop--vertical {
+  overflow: hidden;
+  height: 100%;
+  display: inline-block;
+}
+
+.logoloop--scale-hover {
+  padding-top: calc(var(--logoloop-logoHeight) * 0.1);
+  padding-bottom: calc(var(--logoloop-logoHeight) * 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  .logoloop {
+    --logoloop-fadeColorAuto: #0b0b0b;
+  }
+}
+
+.logoloop__track {
+  display: flex;
+  width: max-content;
+  will-change: transform;
+  user-select: none;
+  position: relative;
+  z-index: 0;
+}
+
+.logoloop--vertical .logoloop__track {
+  flex-direction: column;
+  height: max-content;
+  width: 100%;
+}
+
+.logoloop__list {
+  display: flex;
+  align-items: center;
+}
+
+.logoloop--vertical .logoloop__list {
+  flex-direction: column;
+}
+
+.logoloop__item {
+  flex: 0 0 auto;
+  margin-right: var(--logoloop-gap);
+  font-size: var(--logoloop-logoHeight);
+  line-height: 1;
+}
+
+.logoloop--vertical .logoloop__item {
+  margin-right: 0;
+  margin-bottom: var(--logoloop-gap);
+}
+
+.logoloop__item:last-child {
+  margin-right: var(--logoloop-gap);
+}
+
+.logoloop--vertical .logoloop__item:last-child {
+  margin-right: 0;
+  margin-bottom: var(--logoloop-gap);
+}
+
+.logoloop__node {
+  display: inline-flex;
+  align-items: center;
+}
+
+.logoloop__item img {
+  height: var(--logoloop-logoHeight);
+  width: auto;
+  display: block;
+  object-fit: contain;
+  image-rendering: -webkit-optimize-contrast;
+  -webkit-user-drag: none;
+  pointer-events: none;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.logoloop--scale-hover .logoloop__item {
+  overflow: visible;
+}
+
+.logoloop--scale-hover .logoloop__item:hover img,
+.logoloop--scale-hover .logoloop__item:hover .logoloop__node {
+  transform: scale(1.2);
+  transform-origin: center center;
+}
+
+.logoloop--scale-hover .logoloop__node {
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.logoloop__link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: opacity 0.2s ease;
+}
+
+.logoloop__link:hover {
+  opacity: 0.8;
+}
+
+.logoloop__link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.logoloop--fade::before,
+.logoloop--fade::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: clamp(24px, 8%, 120px);
+  pointer-events: none;
+  z-index: 10;
+}
+
+.logoloop--fade::before {
+  left: 0;
+  background: linear-gradient(
+    to right,
+    var(--logoloop-fadeColor, var(--logoloop-fadeColorAuto)) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.logoloop--fade::after {
+  right: 0;
+  background: linear-gradient(
+    to left,
+    var(--logoloop-fadeColor, var(--logoloop-fadeColorAuto)) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.logoloop--vertical.logoloop--fade::before,
+.logoloop--vertical.logoloop--fade::after {
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: clamp(24px, 8%, 120px);
+}
+
+.logoloop--vertical.logoloop--fade::before {
+  top: 0;
+  bottom: auto;
+  background: linear-gradient(
+    to bottom,
+    var(--logoloop-fadeColor, var(--logoloop-fadeColorAuto)) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.logoloop--vertical.logoloop--fade::after {
+  bottom: 0;
+  top: auto;
+  background: linear-gradient(
+    to top,
+    var(--logoloop-fadeColor, var(--logoloop-fadeColorAuto)) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logoloop__track {
+    transform: translate3d(0, 0, 0) !important;
+  }
+
+  .logoloop__item img,
+  .logoloop__node {
+    transition: none !important;
+  }
+}

--- a/src/components/LogoLoop/LogoLoop.css
+++ b/src/components/LogoLoop/LogoLoop.css
@@ -42,6 +42,9 @@
 .logoloop__list {
   display: flex;
   align-items: center;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .logoloop--vertical .logoloop__list {

--- a/src/components/LogoLoop/LogoLoop.tsx
+++ b/src/components/LogoLoop/LogoLoop.tsx
@@ -1,0 +1,391 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import './LogoLoop.css';
+
+export type LogoItem =
+  | {
+      node: React.ReactNode;
+      href?: string;
+      title?: string;
+      ariaLabel?: string;
+    }
+  | {
+      src: string;
+      alt?: string;
+      href?: string;
+      title?: string;
+      srcSet?: string;
+      sizes?: string;
+      width?: number;
+      height?: number;
+    };
+
+export interface LogoLoopProps {
+  logos: LogoItem[];
+  speed?: number;
+  direction?: 'left' | 'right' | 'up' | 'down';
+  width?: number | string;
+  logoHeight?: number;
+  gap?: number;
+  pauseOnHover?: boolean;
+  hoverSpeed?: number;
+  fadeOut?: boolean;
+  fadeOutColor?: string;
+  scaleOnHover?: boolean;
+  renderItem?: (item: LogoItem, key: React.Key) => React.ReactNode;
+  ariaLabel?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const ANIMATION_CONFIG = {
+  SMOOTH_TAU: 0.25,
+  MIN_COPIES: 2,
+  COPY_HEADROOM: 2
+} as const;
+
+const toCssLength = (value?: number | string): string | undefined =>
+  typeof value === 'number' ? `${value}px` : (value ?? undefined);
+
+const useResizeObserver = (
+  callback: () => void,
+  elements: Array<React.RefObject<Element | null>>,
+  dependencies: React.DependencyList
+) => {
+  useEffect(() => {
+    if (!window.ResizeObserver) {
+      const handleResize = () => callback();
+      window.addEventListener('resize', handleResize);
+      callback();
+      return () => window.removeEventListener('resize', handleResize);
+    }
+
+    const observers = elements.map(ref => {
+      if (!ref.current) return null;
+      const observer = new ResizeObserver(callback);
+      observer.observe(ref.current);
+      return observer;
+    });
+
+    callback();
+
+    return () => {
+      observers.forEach(observer => observer?.disconnect());
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+};
+
+const useImageLoader = (
+  seqRef: React.RefObject<HTMLUListElement | null>,
+  onLoad: () => void,
+  dependencies: React.DependencyList
+) => {
+  useEffect(() => {
+    const images = seqRef.current?.querySelectorAll('img') ?? [];
+
+    if (images.length === 0) {
+      onLoad();
+      return;
+    }
+
+    let remainingImages = images.length;
+    const handleImageLoad = () => {
+      remainingImages -= 1;
+      if (remainingImages === 0) {
+        onLoad();
+      }
+    };
+
+    images.forEach(img => {
+      const htmlImg = img as HTMLImageElement;
+      if (htmlImg.complete) {
+        handleImageLoad();
+      } else {
+        htmlImg.addEventListener('load', handleImageLoad, { once: true });
+        htmlImg.addEventListener('error', handleImageLoad, { once: true });
+      }
+    });
+
+    return () => {
+      images.forEach(img => {
+        img.removeEventListener('load', handleImageLoad);
+        img.removeEventListener('error', handleImageLoad);
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+};
+
+const useAnimationLoop = (
+  trackRef: React.RefObject<HTMLDivElement | null>,
+  targetVelocity: number,
+  seqWidth: number,
+  seqHeight: number,
+  isHovered: boolean,
+  hoverSpeed: number | undefined,
+  isVertical: boolean
+) => {
+  const rafRef = useRef<number | null>(null);
+  const lastTimestampRef = useRef<number | null>(null);
+  const offsetRef = useRef(0);
+  const velocityRef = useRef(0);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const seqSize = isVertical ? seqHeight : seqWidth;
+
+    if (seqSize > 0) {
+      offsetRef.current = ((offsetRef.current % seqSize) + seqSize) % seqSize;
+      const transformValue = isVertical
+        ? `translate3d(0, ${-offsetRef.current}px, 0)`
+        : `translate3d(${-offsetRef.current}px, 0, 0)`;
+      track.style.transform = transformValue;
+    }
+
+    const animate = (timestamp: number) => {
+      if (lastTimestampRef.current === null) {
+        lastTimestampRef.current = timestamp;
+      }
+
+      const deltaTime = Math.max(0, timestamp - lastTimestampRef.current) / 1000;
+      lastTimestampRef.current = timestamp;
+
+      const target = isHovered && hoverSpeed !== undefined ? hoverSpeed : targetVelocity;
+
+      const easingFactor = 1 - Math.exp(-deltaTime / ANIMATION_CONFIG.SMOOTH_TAU);
+      velocityRef.current += (target - velocityRef.current) * easingFactor;
+
+      if (seqSize > 0) {
+        let nextOffset = offsetRef.current + velocityRef.current * deltaTime;
+        nextOffset = ((nextOffset % seqSize) + seqSize) % seqSize;
+        offsetRef.current = nextOffset;
+
+        const transformValue = isVertical
+          ? `translate3d(0, ${-offsetRef.current}px, 0)`
+          : `translate3d(${-offsetRef.current}px, 0, 0)`;
+        track.style.transform = transformValue;
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      lastTimestampRef.current = null;
+    };
+  }, [trackRef, targetVelocity, seqWidth, seqHeight, isHovered, hoverSpeed, isVertical]);
+};
+
+export const LogoLoop = React.memo<LogoLoopProps>(
+  ({
+    logos,
+    speed = 120,
+    direction = 'left',
+    width = '100%',
+    logoHeight = 28,
+    gap = 32,
+    pauseOnHover,
+    hoverSpeed,
+    fadeOut = false,
+    fadeOutColor,
+    scaleOnHover = false,
+    renderItem,
+    ariaLabel = 'Partner logos',
+    className,
+    style
+  }) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const trackRef = useRef<HTMLDivElement>(null);
+    const seqRef = useRef<HTMLUListElement>(null);
+
+    const [seqWidth, setSeqWidth] = useState<number>(0);
+    const [seqHeight, setSeqHeight] = useState<number>(0);
+    const [copyCount, setCopyCount] = useState<number>(ANIMATION_CONFIG.MIN_COPIES);
+    const [isHovered, setIsHovered] = useState<boolean>(false);
+
+    const effectiveHoverSpeed = useMemo(() => {
+      if (hoverSpeed !== undefined) return hoverSpeed;
+      if (pauseOnHover === true) return 0;
+      if (pauseOnHover === false) return undefined;
+      return 0;
+    }, [hoverSpeed, pauseOnHover]);
+
+    const isVertical = direction === 'up' || direction === 'down';
+
+    const targetVelocity = useMemo(() => {
+      const magnitude = Math.abs(speed);
+      let directionMultiplier: number;
+      if (isVertical) {
+        directionMultiplier = direction === 'up' ? 1 : -1;
+      } else {
+        directionMultiplier = direction === 'left' ? 1 : -1;
+      }
+      const speedMultiplier = speed < 0 ? -1 : 1;
+      return magnitude * directionMultiplier * speedMultiplier;
+    }, [speed, direction, isVertical]);
+
+    const updateDimensions = useCallback(() => {
+      const containerWidth = containerRef.current?.clientWidth ?? 0;
+      const sequenceRect = seqRef.current?.getBoundingClientRect?.();
+      const sequenceWidth = sequenceRect?.width ?? 0;
+      const sequenceHeight = sequenceRect?.height ?? 0;
+      if (isVertical) {
+        const parentHeight = containerRef.current?.parentElement?.clientHeight ?? 0;
+        if (containerRef.current && parentHeight > 0) {
+          const targetHeight = Math.ceil(parentHeight);
+          if (containerRef.current.style.height !== `${targetHeight}px`)
+            containerRef.current.style.height = `${targetHeight}px`;
+        }
+        if (sequenceHeight > 0) {
+          setSeqHeight(Math.ceil(sequenceHeight));
+          const viewport = containerRef.current?.clientHeight ?? parentHeight ?? sequenceHeight;
+          const copiesNeeded = Math.ceil(viewport / sequenceHeight) + ANIMATION_CONFIG.COPY_HEADROOM;
+          setCopyCount(Math.max(ANIMATION_CONFIG.MIN_COPIES, copiesNeeded));
+        }
+      } else if (sequenceWidth > 0) {
+        setSeqWidth(Math.ceil(sequenceWidth));
+        const copiesNeeded = Math.ceil(containerWidth / sequenceWidth) + ANIMATION_CONFIG.COPY_HEADROOM;
+        setCopyCount(Math.max(ANIMATION_CONFIG.MIN_COPIES, copiesNeeded));
+      }
+    }, [isVertical]);
+
+    useResizeObserver(updateDimensions, [containerRef, seqRef], [logos, gap, logoHeight, isVertical]);
+
+    useImageLoader(seqRef, updateDimensions, [logos, gap, logoHeight, isVertical]);
+
+    useAnimationLoop(trackRef, targetVelocity, seqWidth, seqHeight, isHovered, effectiveHoverSpeed, isVertical);
+
+    const cssVariables = useMemo(
+      () =>
+        ({
+          '--logoloop-gap': `${gap}px`,
+          '--logoloop-logoHeight': `${logoHeight}px`,
+          ...(fadeOutColor && { '--logoloop-fadeColor': fadeOutColor })
+        }) as React.CSSProperties,
+      [gap, logoHeight, fadeOutColor]
+    );
+
+    const rootClassName = useMemo(
+      () =>
+        [
+          'logoloop',
+          isVertical ? 'logoloop--vertical' : 'logoloop--horizontal',
+          fadeOut && 'logoloop--fade',
+          scaleOnHover && 'logoloop--scale-hover',
+          className
+        ]
+          .filter(Boolean)
+          .join(' '),
+      [isVertical, fadeOut, scaleOnHover, className]
+    );
+
+    const handleMouseEnter = useCallback(() => {
+      if (effectiveHoverSpeed !== undefined) setIsHovered(true);
+    }, [effectiveHoverSpeed]);
+    const handleMouseLeave = useCallback(() => {
+      if (effectiveHoverSpeed !== undefined) setIsHovered(false);
+    }, [effectiveHoverSpeed]);
+
+    const renderLogoItem = useCallback(
+      (item: LogoItem, key: React.Key) => {
+        if (renderItem) {
+          return (
+            <li className="logoloop__item" key={key} role="listitem">
+              {renderItem(item, key)}
+            </li>
+          );
+        }
+        const isNodeItem = 'node' in item;
+        const content = isNodeItem ? (
+          <span className="logoloop__node" aria-hidden={!!item.href && !item.ariaLabel}>
+            {(item as { node: React.ReactNode }).node}
+          </span>
+        ) : (
+          <img
+            src={(item as { src: string }).src}
+            srcSet={(item as { srcSet?: string }).srcSet}
+            sizes={(item as { sizes?: string }).sizes}
+            width={(item as { width?: number }).width}
+            height={(item as { height?: number }).height}
+            alt={(item as { alt?: string }).alt ?? ''}
+            title={(item as { title?: string }).title}
+            loading="lazy"
+            decoding="async"
+            draggable={false}
+          />
+        );
+        const itemAriaLabel = isNodeItem
+          ? ((item as { ariaLabel?: string; title?: string }).ariaLabel ?? (item as { title?: string }).title)
+          : ((item as { alt?: string; title?: string }).alt ?? (item as { title?: string }).title);
+        const href = (item as { href?: string }).href;
+        const itemContent = href ? (
+          <a
+            className="logoloop__link"
+            href={href}
+            aria-label={itemAriaLabel || 'logo link'}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {content}
+          </a>
+        ) : (
+          content
+        );
+        return (
+          <li className="logoloop__item" key={key} role="listitem">
+            {itemContent}
+          </li>
+        );
+      },
+      [renderItem]
+    );
+
+    const logoLists = useMemo(
+      () =>
+        Array.from({ length: copyCount }, (_, copyIndex) => (
+          <ul
+            className="logoloop__list"
+            key={`copy-${copyIndex}`}
+            role="list"
+            aria-hidden={copyIndex > 0}
+            ref={copyIndex === 0 ? seqRef : undefined}
+          >
+            {logos.map((item, itemIndex) => renderLogoItem(item, `${copyIndex}-${itemIndex}`))}
+          </ul>
+        )),
+      [copyCount, logos, renderLogoItem]
+    );
+
+    const containerStyle = useMemo(
+      (): React.CSSProperties => ({
+        width: isVertical
+          ? toCssLength(width) === '100%'
+            ? undefined
+            : toCssLength(width)
+          : (toCssLength(width) ?? '100%'),
+        ...cssVariables,
+        ...style
+      }),
+      [width, cssVariables, style, isVertical]
+    );
+
+    return (
+      <div ref={containerRef} className={rootClassName} style={containerStyle} role="region" aria-label={ariaLabel}>
+        <div className="logoloop__track" ref={trackRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+          {logoLists}
+        </div>
+      </div>
+    );
+  }
+);
+
+LogoLoop.displayName = 'LogoLoop';
+
+export default LogoLoop;

--- a/src/components/LogoLoop/index.ts
+++ b/src/components/LogoLoop/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./LogoLoop";
+export type { LogoItem, LogoLoopProps } from "./LogoLoop";

--- a/src/components/MySkills/MySkills.css
+++ b/src/components/MySkills/MySkills.css
@@ -3,61 +3,24 @@
 }
 
 #skill .skill-wrap {
-  display: flex;
-  text-align: center;
-  flex-wrap: wrap;
   max-width: 80%;
-  justify-content: space-around;
-  margin-left: 10%;
-  padding: 30px 20px;
+  margin: 0 auto;
+  padding: 40px 24px;
   font-family: "Quicksand", sans-serif;
   color: #333;
+  box-sizing: border-box;
 }
 
-#skill .skill-wrap .skill-item {
-  text-align: center;
-}
-
-#skill .fab {
-  font-size: 5rem;
-  transition: all 0.5s;
-}
-
-#skill .fab:hover {
-  transform: rotate(-25deg);
-  transition: all 0.5s;
-}
-
-@media screen and (max-width: 1000px) {
-  #skill .fab {
-    font-size: 4rem;
-  }
-}
-
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 768px) {
   #skill .skill-wrap {
-    width: 80%;
-    padding: 10px 20px;
-    margin: 0 auto;
-    font-size: 0.7rem;
-  }
-  #skill .fab {
-    font-size: 3rem;
+    max-width: 92%;
+    padding: 28px 16px;
   }
 }
 
 @media screen and (max-width: 480px) {
   #skill .skill-wrap {
-    width: 75%;
-    padding: 10px 10px;
-    margin: 0 auto;
-    font-size: 0.5rem;
-  }
-  #skill .skill-item {
-    padding-right: 5px;
-    padding-left: 5px;
-  }
-  #skill .fab {
-    font-size: 2rem;
+    max-width: 94%;
+    padding: 20px 12px;
   }
 }

--- a/src/components/MySkills/MySkills.tsx
+++ b/src/components/MySkills/MySkills.tsx
@@ -13,58 +13,54 @@ import {
   SiKubernetes,
 } from "react-icons/si";
 import { FaNodeJs, FaVuejs } from "react-icons/fa";
+import LogoLoop, { type LogoItem } from "../LogoLoop";
+import { useViewport } from "../../hooks/useViewport";
+
+const skillLogos: LogoItem[] = [
+  { node: <SiHtml5 color="#E34F26" />, title: "HTML5", ariaLabel: "HTML5" },
+  { node: <SiCss color="#1572B6" />, title: "CSS3", ariaLabel: "CSS3" },
+  { node: <SiJavascript color="#F7DF1E" />, title: "JavaScript", ariaLabel: "JavaScript" },
+  { node: <SiReact color="#61DAFB" />, title: "React.js", ariaLabel: "React.js" },
+  { node: <SiNextdotjs color="#000000" />, title: "Next.js", ariaLabel: "Next.js" },
+  { node: <FaVuejs color="#4FC08D" />, title: "Vue.js", ariaLabel: "Vue.js" },
+  { node: <SiNuxt color="#00DC82" />, title: "Nuxt.js", ariaLabel: "Nuxt.js" },
+  { node: <SiTypescript color="#007ACC" />, title: "TypeScript", ariaLabel: "TypeScript" },
+  { node: <FaNodeJs color="#339933" />, title: "Node.js", ariaLabel: "Node.js" },
+  { node: <SiKubernetes color="#326CE5" />, title: "Kubernetes", ariaLabel: "Kubernetes" },
+  { node: <SiWordpress color="#21759B" />, title: "WordPress", ariaLabel: "WordPress" },
+  { node: <SiShopify color="#96BF48" />, title: "Shopify", ariaLabel: "Shopify" },
+];
+
+const getLogoHeight = (width: number): number => {
+  if (width <= 374) return 40;
+  if (width <= 480) return 48;
+  if (width <= 768) return 56;
+  return 72;
+};
+
+const getGap = (width: number): number => {
+  if (width <= 480) return 32;
+  if (width <= 768) return 40;
+  return 56;
+};
 
 const MySkills: React.FC = () => {
+  const { width } = useViewport();
+
   return (
     <div className="skill-wrap wrapper">
-      <div className="skill-item">
-        <SiHtml5 size={80} color="#E34F26" title="HTML5" />
-        <h4>HTML</h4>
-      </div>
-      <div className="skill-item">
-        <SiCss size={80} color="#1572B6" title="CSS3" />
-        <h4>CSS</h4>
-      </div>
-      <div className="skill-item">
-        <SiJavascript size={80} color="#F7DF1E" title="JavaScript" />
-        <h4>JavaScript</h4>
-      </div>
-      <div className="skill-item">
-        <SiReact size={80} color="#61DAFB" title="React" />
-        <h4>React.js</h4>
-      </div>
-      <div className="skill-item">
-        <SiNextdotjs size={80} color="#000000" title="React" />
-        <h4>Next.js</h4>
-      </div>
-      <div className="skill-item">
-        <FaVuejs size={80} color="#4FC08D" title="Vue.js" />
-        <h4>Vue.js</h4>
-      </div>
-      <div className="skill-item">
-        <SiNuxt size={80} color="#00DC82" title="Nuxt.js" />
-        <h4>Nuxt.js</h4>
-      </div>
-      <div className="skill-item">
-        <SiTypescript size={80} color="#007ACC" />
-        <h4>TypeScript</h4>
-      </div>
-      <div className="skill-item">
-        <FaNodeJs size={80} color="#339933" />
-        <h4>Node.js</h4>
-      </div>
-      <div className="skill-item">
-        <SiKubernetes size={80} color="#326CE5" title="Kubernetes" />
-        <h4>Kubernetes</h4>
-      </div>
-      <div className="skill-item">
-        <SiWordpress size={80} color="#21759B" title="WordPress" />
-        <h4>WordPress</h4>
-      </div>
-      <div className="skill-item">
-        <SiShopify size={80} color="#96BF48" title="Shopify" />
-        <h4>Shopify</h4>
-      </div>
+      <LogoLoop
+        logos={skillLogos}
+        speed={90}
+        direction="left"
+        logoHeight={getLogoHeight(width)}
+        gap={getGap(width)}
+        pauseOnHover
+        scaleOnHover
+        fadeOut
+        fadeOutColor="#ffffff"
+        ariaLabel="My skills"
+      />
     </div>
   );
 };


### PR DESCRIPTION
Closes #49

## 概要
`MySkills` の技術アイコン表示を、reactbits.dev の **LogoLoop** を使った横スクロールループ演出に置き換え。

## 変更内容
- `src/components/LogoLoop/` に reactbits の LogoLoop を取り込み
  - 元ソース: `DavidHDev/react-bits` (ts-default)
  - 上流の `as any` キャストはより具体的な型キャストに置き換え
- `MySkills.tsx` を全面リファクタ
  - 12 個の技術アイコン（react-icons）を `LogoLoop` の `logos[].node` として渡す
  - `useViewport` で `logoHeight`（40/48/56/72）と `gap`（32/40/56）を viewport 幅に応じて切替
  - props: `speed=90` / `pauseOnHover` / `scaleOnHover` / `fadeOut`
  - `.wrapper` 内の白背景に合わせて `fadeOutColor=#ffffff`
- `MySkills.css` を整理
  - 旧 `.fab` / `.skill-item` 個別レイアウトルールを撤去（LogoLoop 側がレイアウトを担当）
  - ラッパー側の幅・パディングのみ残し、PC / SP の breakpoint を整理
- 技術名のテキストラベルは撤去（流れる演出と相性が悪いため）
  - 各アイコンの `title` / `ariaLabel` には技術名を保持し、ホバー時のツールチップ・スクリーンリーダー読み上げで内容を補完

## アクセシビリティ
- `prefers-reduced-motion: reduce` 環境では LogoLoop 側でループが停止（既定動作）
- 各ロゴに `title` / `ariaLabel` を付与
- リージョンに `aria-label="My skills"`

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功
- [x] `yarn dev` → 起動エラーなし
- [ ] ブラウザで以下を目視確認お願いします:
  - [ ] アイコンが左方向に連続ループする
  - [ ] ホバーで停止し、対象アイコンが拡大される
  - [ ] PC / SP でレイアウトが破綻しない
  - [ ] 両端のフェード演出が白背景になじむ
  - [ ] OS の「視差を減らす」設定でループが止まる

## 留意点 / 今後
- 技術名ラベルを完全撤去したのは、横ループ表示でテキストが流れると可読性が落ちるため。必要であれば「アイコン下に小さく技術名」「中央固定の凡例」などの追加表示は別 Issue でフォロー可能
- LogoLoop は内部で `requestAnimationFrame` でループするため、長時間放置時の CPU 影響は軽微（hover 停止あり）

## アウトオブスコープ
- 表示する技術アイコンの追加・削除
- skill セクションのリブランディング（背景色など）