### PR TITLE
feat: Profile を JA/EN 切替対応 + タブに TargetCursor 演出を適用

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "framer-motion": "^12.19.1",
+    "gsap": "^3.15.0",
     "ogl": "^1.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import TopFv from "./components/TopFv";
 import HomePage from "./components/HomePage";
 import Footer from "./components/Footer";
 import Contact from "./components/Contact";
+import TargetCursor from "./components/TargetCursor";
 
 // グローバルスタイルを作成
 const GlobalStyle = createGlobalStyle`
@@ -43,6 +44,7 @@ const App: React.FC = () => {
   return (
   <>
     <GlobalStyle />
+    <TargetCursor targetSelector=".cursor-target" />
     <div className="App">
       <Header />
       <TopFv />

--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -2,6 +2,45 @@
   padding-bottom: 70px;
 }
 
+.profile-lang-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin: 16px 0 28px;
+}
+
+.profile-lang-tab {
+  appearance: none;
+  background: transparent;
+  border: 1px solid rgba(255, 46, 99, 0.6);
+  color: #ff2e63;
+  padding: 8px 20px;
+  min-width: 64px;
+  min-height: 36px;
+  font-family: "Quicksand", sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 2px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-lang-tab:hover {
+  background-color: rgba(255, 46, 99, 0.08);
+}
+
+.profile-lang-tab.is-active {
+  background-color: #ff2e63;
+  color: #fff;
+  box-shadow: 0 0 8px rgba(255, 46, 99, 0.45);
+}
+
+.profile-lang-tab:focus-visible {
+  outline: 2px solid #ff2e63;
+  outline-offset: 2px;
+}
+
 #about .icon-wrapper {
   width: 80%;
   margin-right: 10%;

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,7 +1,53 @@
-import React from "react";
+import React, { useState } from "react";
 import "./Profile.css";
 
+type Locale = "ja" | "en";
+
+type ProfileContent = {
+  historyHeading: string;
+  historyItems: React.ReactNode[];
+  mindHeading: string;
+  mind: React.ReactNode;
+};
+
+const content: Record<Locale, ProfileContent> = {
+  ja: {
+    historyHeading: "Personal History",
+    historyItems: [
+      "東京育ち、東京在住",
+      "都内のShopify専門制作会社でフロントエンドエンジニアとして勤務したのちに、Webアプリケーション開発のフロントエンドエンジニアに転身",
+      "Shopifyを使ったECサイトやLP・コーポレートサイトなどのWebサイト制作を経験後、現在は主にReact.js・Next.js・Vue.js・TypeScriptを使ったフロントエンド開発に取り組む",
+    ],
+    mindHeading: "Mind",
+    mind: (
+      <>
+        技術力向上に日々努力しておりますが、第一に双方すれ違いのない円滑なコミュニケーションを大事に活動しております。
+        業務においては「レスの速さ」を大切にしております。急なデザインの変更や修正なども、その都度しっかりと対応できるように心がけております。
+      </>
+    ),
+  },
+  en: {
+    historyHeading: "Personal History",
+    historyItems: [
+      "Born and raised in Tokyo, currently based in Tokyo.",
+      "Worked as a front-end engineer at a Shopify-focused web production agency in Tokyo, then moved to a front-end engineer role in web application development.",
+      "After building Shopify-based EC sites, landing pages, and corporate websites, I now focus mainly on front-end development with React.js, Next.js, Vue.js, and TypeScript.",
+    ],
+    mindHeading: "Working Style",
+    mind: (
+      <>
+        I work hard every day to improve my technical skills, but above all, I value smooth, well-aligned communication.
+        In my work I place a high priority on the speed of response, and I make sure to handle sudden design changes
+        and revisions promptly and reliably.
+      </>
+    ),
+  },
+};
+
 const Profile: React.FC = () => {
+  const [locale, setLocale] = useState<Locale>("ja");
+  const current = content[locale];
+
   return (
     <div className="profile">
       <div className="icon-wrapper">
@@ -10,30 +56,47 @@ const Profile: React.FC = () => {
           <p className="name-sub">N-i-ke</p>
         </h3>
       </div>
-      <div className="about-wrapper">
+
+      <div className="profile-lang-tabs" role="tablist" aria-label="Language">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={locale === "ja"}
+          className={`profile-lang-tab cursor-target ${locale === "ja" ? "is-active" : ""}`}
+          onClick={() => setLocale("ja")}
+        >
+          JA
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={locale === "en"}
+          className={`profile-lang-tab cursor-target ${locale === "en" ? "is-active" : ""}`}
+          onClick={() => setLocale("en")}
+        >
+          EN
+        </button>
+      </div>
+
+      <div className="about-wrapper" lang={locale}>
         <h4>
           <i className="fas fa-chess-king"></i>
-          Personal History
+          {current.historyHeading}
         </h4>
         <p>
-          <i className="fa-regular fa-dot-circle"></i>
-          東京育ち、東京在住
-          <br />
-          <i className="fa-regular fa-dot-circle"></i>
-          都内のShopify専門制作会社でフロントエンドエンジニアとして勤務したのちに、Webアプリケーション開発のフロントエンドエンジニアに転身
-          <br />
-          <i className="fa-regular fa-dot-circle"></i>
-          Shopifyを使ったECサイトやLP・コーポレートサイトなどのWebサイト制作を経験後、現在は主にReact.js・Next.js・Vue.js・TypeScriptを使ったフロントエンド開発に取り組む
-          <br />
+          {current.historyItems.map((item, index) => (
+            <React.Fragment key={index}>
+              <i className="fa-regular fa-dot-circle"></i>
+              {item}
+              <br />
+            </React.Fragment>
+          ))}
         </p>
         <h4>
           <i className="fas fa-chess-queen"></i>
-          Mind
+          {current.mindHeading}
         </h4>
-        <p>
-          技術力向上に日々努力しておりますが、第一に双方すれ違いのない円滑なコミュニケーションを大事に活動しております。
-          業務においては「レスの速さ」を大切にしております。急なデザインの変更や修正なども、その都度しっかりと対応できるように心がけております。
-        </p>
+        <p>{current.mind}</p>
       </div>
     </div>
   );

--- a/src/components/TargetCursor/TargetCursor.css
+++ b/src/components/TargetCursor/TargetCursor.css
@@ -1,0 +1,57 @@
+.target-cursor-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  z-index: 9999;
+  mix-blend-mode: difference;
+  transform: translate(-50%, -50%);
+}
+
+.target-cursor-dot {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 4px;
+  height: 4px;
+  background: #fff;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  will-change: transform;
+}
+
+.target-cursor-corner {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  border: 3px solid #fff;
+  will-change: transform;
+}
+
+.corner-tl {
+  transform: translate(-150%, -150%);
+  border-right: none;
+  border-bottom: none;
+}
+
+.corner-tr {
+  transform: translate(50%, -150%);
+  border-left: none;
+  border-bottom: none;
+}
+
+.corner-br {
+  transform: translate(50%, 50%);
+  border-left: none;
+  border-top: none;
+}
+
+.corner-bl {
+  transform: translate(-150%, 50%);
+  border-right: none;
+  border-top: none;
+}

--- a/src/components/TargetCursor/TargetCursor.tsx
+++ b/src/components/TargetCursor/TargetCursor.tsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useRef, useCallback, useMemo } from 'react';
+import { gsap } from 'gsap';
+import './TargetCursor.css';
+
+export interface TargetCursorProps {
+  targetSelector?: string;
+  spinDuration?: number;
+  hideDefaultCursor?: boolean;
+  hoverDuration?: number;
+  parallaxOn?: boolean;
+}
+
+const TargetCursor: React.FC<TargetCursorProps> = ({
+  targetSelector = '.cursor-target',
+  spinDuration = 2,
+  hideDefaultCursor = true,
+  hoverDuration = 0.2,
+  parallaxOn = true
+}) => {
+  const cursorRef = useRef<HTMLDivElement>(null);
+  const cornersRef = useRef<NodeListOf<HTMLDivElement> | null>(null);
+  const spinTl = useRef<gsap.core.Timeline | null>(null);
+  const dotRef = useRef<HTMLDivElement>(null);
+
+  const isActiveRef = useRef(false);
+  const targetCornerPositionsRef = useRef<{ x: number; y: number }[] | null>(null);
+  const tickerFnRef = useRef<(() => void) | null>(null);
+  const activeStrengthRef = useRef({ current: 0 });
+
+  const isMobile = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    const isSmallScreen = window.innerWidth <= 768;
+    const userAgent =
+      navigator.userAgent || (window as unknown as { opera?: string }).opera || '';
+    const mobileRegex = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i;
+    const isMobileUserAgent = mobileRegex.test(userAgent.toLowerCase());
+    return (hasTouchScreen && isSmallScreen) || isMobileUserAgent;
+  }, []);
+
+  const constants = useMemo(() => ({ borderWidth: 3, cornerSize: 12 }), []);
+
+  const moveCursor = useCallback((x: number, y: number) => {
+    if (!cursorRef.current) return;
+    gsap.to(cursorRef.current, { x, y, duration: 0.1, ease: 'power3.out' });
+  }, []);
+
+  useEffect(() => {
+    if (isMobile || !cursorRef.current) return;
+
+    const originalCursor = document.body.style.cursor;
+    if (hideDefaultCursor) {
+      document.body.style.cursor = 'none';
+    }
+
+    const cursor = cursorRef.current;
+    cornersRef.current = cursor.querySelectorAll<HTMLDivElement>('.target-cursor-corner');
+
+    let activeTarget: Element | null = null;
+    let currentLeaveHandler: (() => void) | null = null;
+    let resumeTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanupTarget = (target: Element) => {
+      if (currentLeaveHandler) {
+        target.removeEventListener('mouseleave', currentLeaveHandler);
+      }
+      currentLeaveHandler = null;
+    };
+
+    gsap.set(cursor, {
+      xPercent: -50,
+      yPercent: -50,
+      x: window.innerWidth / 2,
+      y: window.innerHeight / 2
+    });
+
+    const createSpinTimeline = () => {
+      if (spinTl.current) {
+        spinTl.current.kill();
+      }
+      spinTl.current = gsap
+        .timeline({ repeat: -1 })
+        .to(cursor, { rotation: '+=360', duration: spinDuration, ease: 'none' });
+    };
+
+    createSpinTimeline();
+
+    const tickerFn = () => {
+      if (!targetCornerPositionsRef.current || !cursorRef.current || !cornersRef.current) {
+        return;
+      }
+      const strength = activeStrengthRef.current.current;
+      if (strength === 0) return;
+      const cursorX = gsap.getProperty(cursorRef.current, 'x') as number;
+      const cursorY = gsap.getProperty(cursorRef.current, 'y') as number;
+      const corners = Array.from(cornersRef.current);
+      corners.forEach((corner, i) => {
+        const currentX = gsap.getProperty(corner, 'x') as number;
+        const currentY = gsap.getProperty(corner, 'y') as number;
+        const targetX = targetCornerPositionsRef.current![i].x - cursorX;
+        const targetY = targetCornerPositionsRef.current![i].y - cursorY;
+        const finalX = currentX + (targetX - currentX) * strength;
+        const finalY = currentY + (targetY - currentY) * strength;
+        const duration = strength >= 0.99 ? (parallaxOn ? 0.2 : 0) : 0.05;
+        gsap.to(corner, {
+          x: finalX,
+          y: finalY,
+          duration: duration,
+          ease: duration === 0 ? 'none' : 'power1.out',
+          overwrite: 'auto'
+        });
+      });
+    };
+
+    tickerFnRef.current = tickerFn;
+
+    const moveHandler = (e: MouseEvent) => moveCursor(e.clientX, e.clientY);
+    window.addEventListener('mousemove', moveHandler);
+
+    const scrollHandler = () => {
+      if (!activeTarget || !cursorRef.current) return;
+      const mouseX = gsap.getProperty(cursorRef.current, 'x') as number;
+      const mouseY = gsap.getProperty(cursorRef.current, 'y') as number;
+      const elementUnderMouse = document.elementFromPoint(mouseX, mouseY);
+      const isStillOverTarget =
+        elementUnderMouse &&
+        (elementUnderMouse === activeTarget || elementUnderMouse.closest(targetSelector) === activeTarget);
+      if (!isStillOverTarget) {
+        currentLeaveHandler?.();
+      }
+    };
+    window.addEventListener('scroll', scrollHandler, { passive: true });
+
+    const mouseDownHandler = () => {
+      if (!dotRef.current) return;
+      gsap.to(dotRef.current, { scale: 0.7, duration: 0.3 });
+      gsap.to(cursorRef.current, { scale: 0.9, duration: 0.2 });
+    };
+
+    const mouseUpHandler = () => {
+      if (!dotRef.current) return;
+      gsap.to(dotRef.current, { scale: 1, duration: 0.3 });
+      gsap.to(cursorRef.current, { scale: 1, duration: 0.2 });
+    };
+
+    window.addEventListener('mousedown', mouseDownHandler);
+    window.addEventListener('mouseup', mouseUpHandler);
+
+    const enterHandler = (e: MouseEvent) => {
+      const directTarget = e.target as Element;
+      const allTargets: Element[] = [];
+      let current: Element | null = directTarget;
+      while (current && current !== document.body) {
+        if (current.matches(targetSelector)) {
+          allTargets.push(current);
+        }
+        current = current.parentElement;
+      }
+      const target = allTargets[0] || null;
+      if (!target || !cursorRef.current || !cornersRef.current) return;
+      if (activeTarget === target) return;
+      if (activeTarget) {
+        cleanupTarget(activeTarget);
+      }
+      if (resumeTimeout) {
+        clearTimeout(resumeTimeout);
+        resumeTimeout = null;
+      }
+
+      activeTarget = target;
+      const corners = Array.from(cornersRef.current);
+      corners.forEach(corner => gsap.killTweensOf(corner));
+      gsap.killTweensOf(cursorRef.current, 'rotation');
+      spinTl.current?.pause();
+      gsap.set(cursorRef.current, { rotation: 0 });
+
+      const rect = target.getBoundingClientRect();
+      const { borderWidth, cornerSize } = constants;
+      const cursorX = gsap.getProperty(cursorRef.current, 'x') as number;
+      const cursorY = gsap.getProperty(cursorRef.current, 'y') as number;
+
+      targetCornerPositionsRef.current = [
+        { x: rect.left - borderWidth, y: rect.top - borderWidth },
+        { x: rect.right + borderWidth - cornerSize, y: rect.top - borderWidth },
+        { x: rect.right + borderWidth - cornerSize, y: rect.bottom + borderWidth - cornerSize },
+        { x: rect.left - borderWidth, y: rect.bottom + borderWidth - cornerSize }
+      ];
+
+      isActiveRef.current = true;
+      gsap.ticker.add(tickerFnRef.current!);
+
+      gsap.to(activeStrengthRef.current, { current: 1, duration: hoverDuration, ease: 'power2.out' });
+
+      corners.forEach((corner, i) => {
+        gsap.to(corner, {
+          x: targetCornerPositionsRef.current![i].x - cursorX,
+          y: targetCornerPositionsRef.current![i].y - cursorY,
+          duration: 0.2,
+          ease: 'power2.out'
+        });
+      });
+
+      const leaveHandler = () => {
+        gsap.ticker.remove(tickerFnRef.current!);
+        isActiveRef.current = false;
+        targetCornerPositionsRef.current = null;
+        gsap.set(activeStrengthRef.current, { current: 0, overwrite: true });
+        activeTarget = null;
+        if (cornersRef.current) {
+          const corners = Array.from(cornersRef.current);
+          gsap.killTweensOf(corners);
+          const { cornerSize } = constants;
+          const positions = [
+            { x: -cornerSize * 1.5, y: -cornerSize * 1.5 },
+            { x: cornerSize * 0.5, y: -cornerSize * 1.5 },
+            { x: cornerSize * 0.5, y: cornerSize * 0.5 },
+            { x: -cornerSize * 1.5, y: cornerSize * 0.5 }
+          ];
+          const tl = gsap.timeline();
+          corners.forEach((corner, index) => {
+            tl.to(corner, { x: positions[index].x, y: positions[index].y, duration: 0.3, ease: 'power3.out' }, 0);
+          });
+        }
+        resumeTimeout = setTimeout(() => {
+          if (!activeTarget && cursorRef.current && spinTl.current) {
+            const currentRotation = gsap.getProperty(cursorRef.current, 'rotation') as number;
+            const normalizedRotation = currentRotation % 360;
+            spinTl.current.kill();
+            spinTl.current = gsap
+              .timeline({ repeat: -1 })
+              .to(cursorRef.current, { rotation: '+=360', duration: spinDuration, ease: 'none' });
+            gsap.to(cursorRef.current, {
+              rotation: normalizedRotation + 360,
+              duration: spinDuration * (1 - normalizedRotation / 360),
+              ease: 'none',
+              onComplete: () => {
+                spinTl.current?.restart();
+              }
+            });
+          }
+          resumeTimeout = null;
+        }, 50);
+        cleanupTarget(target);
+      };
+      currentLeaveHandler = leaveHandler;
+      target.addEventListener('mouseleave', leaveHandler);
+    };
+
+    window.addEventListener('mouseover', enterHandler as EventListener);
+
+    return () => {
+      if (tickerFnRef.current) {
+        gsap.ticker.remove(tickerFnRef.current);
+      }
+      window.removeEventListener('mousemove', moveHandler);
+      window.removeEventListener('mouseover', enterHandler as EventListener);
+      window.removeEventListener('scroll', scrollHandler);
+      window.removeEventListener('mousedown', mouseDownHandler);
+      window.removeEventListener('mouseup', mouseUpHandler);
+      if (activeTarget) {
+        cleanupTarget(activeTarget);
+      }
+      spinTl.current?.kill();
+      document.body.style.cursor = originalCursor;
+      isActiveRef.current = false;
+      targetCornerPositionsRef.current = null;
+      activeStrengthRef.current.current = 0;
+    };
+  }, [targetSelector, spinDuration, moveCursor, constants, hideDefaultCursor, isMobile, hoverDuration, parallaxOn]);
+
+  useEffect(() => {
+    if (isMobile || !cursorRef.current || !spinTl.current) return;
+    if (spinTl.current.isActive()) {
+      spinTl.current.kill();
+      spinTl.current = gsap
+        .timeline({ repeat: -1 })
+        .to(cursorRef.current, { rotation: '+=360', duration: spinDuration, ease: 'none' });
+    }
+  }, [spinDuration, isMobile]);
+
+  if (isMobile) {
+    return null;
+  }
+
+  return (
+    <div ref={cursorRef} className="target-cursor-wrapper">
+      <div ref={dotRef} className="target-cursor-dot" />
+      <div className="target-cursor-corner corner-tl" />
+      <div className="target-cursor-corner corner-tr" />
+      <div className="target-cursor-corner corner-br" />
+      <div className="target-cursor-corner corner-bl" />
+    </div>
+  );
+};
+
+export default TargetCursor;

--- a/src/components/TargetCursor/index.ts
+++ b/src/components/TargetCursor/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TargetCursor";
+export type { TargetCursorProps } from "./TargetCursor";

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,6 +641,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+gsap@^3.15.0:
+  version "3.15.0"
+  resolved "http://edge.artifactory.corp.yahoo.co.jp:8000/artifactory/api/npm/apj-npm/gsap/-/gsap-3.15.0.tgz#7851baaffc77642f2db3b1749d3634f9b5a19d14"
+  integrity sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Closes #51

## 概要
About セクション（Personal History / Mind）を JA / EN タブで切替表示できるようにし、タブには reactbits.dev の TargetCursor アニメーション（ホバー時にカーソルが四隅にロックオン）を適用。

## 変更内容
### 依存追加
- `gsap@^3.15` を `dependencies` に追加（TargetCursor が内部で利用）

### TargetCursor
- `src/components/TargetCursor/` に reactbits の TSX + CSS を取り込み
  - 上流の `navigator.vendor`（deprecated）を撤去
- `App.tsx` で `<TargetCursor targetSelector=".cursor-target" />` を 1 つだけグローバルマウント
- SP（タッチ + 768px 以下 / mobile UA）では内部判定で何も描画されない（既定挙動）

### Profile の JA/EN 切替
- `useState<'ja' | 'en'>` でアクティブ言語管理
- 翻訳辞書を `Profile.tsx` 内に同梱（Personal History / Working Style）
- セマンティクス:
  - タブコンテナに `role="tablist"` / `aria-label="Language"`
  - 各タブに `role="tab"` + `aria-selected`
  - 本文ラッパーに `lang={locale}`
- タブには `cursor-target` クラスを付与し、TargetCursor のロックオン対象に
- アクティブタブはピンク背景 + グロー、非アクティブはアウトラインのみ
- `focus-visible` 対応、`min-height: 36px` でキー操作・タップ両対応

### 翻訳
| 項目 | JA | EN |
|---|---|---|
| 見出し1 | Personal History | Personal History |
| 見出し2 | Mind | Working Style |
| 本文 | 既存 | 新規（README やコミットメッセージとは独立に書き下ろし） |

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功（バンドルサイズは gsap 追加で +30KB gzip 程度）
- [x] `yarn dev` → 起動エラーなし
- [ ] ブラウザ目視:
  - [ ] About の JA / EN タブをクリックして本文が切り替わる
  - [ ] PC でタブにマウスを乗せると TargetCursor の四隅がロックオンする
  - [ ] SP では TargetCursor が無効、タブ機能だけ動作する
  - [ ] フォーカス時のアウトラインが見える（キーボード操作）

## 留意点 / 今後の TODO
- 翻訳はノンネイティブの書き下ろし。気になる箇所があれば PR コメントで指摘してください
- 現状サイトの他セクション（Service / Footer など）はまだ日本語のみ。`locale` 状態を Context に持ち上げてサイト全体多言語化するのは別 Issue 推奨
- `localStorage` で言語選択の永続化は今回は入れていない（要望次第で別 Issue）
- TargetCursor は `mix-blend-mode: difference` で描画するため、背景色によっては視認性が変わる。気になる箇所があれば調整します

## アウトオブスコープ
- サイト全体の多言語化
- next-i18next 等の本格的な i18n フレームワーク
- 翻訳のネイティブチェック