### PR TITLE
fix: yarn.lock の gsap 解決 URL を public npm registry に修正

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -643,7 +643,7 @@ gensync@^1.0.0-beta.2:
 
 gsap@^3.15.0:
   version "3.15.0"
-  resolved "http://edge.artifactory.corp.yahoo.co.jp:8000/artifactory/api/npm/apj-npm/gsap/-/gsap-3.15.0.tgz#7851baaffc77642f2db3b1749d3634f9b5a19d14"
+  resolved "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz#7851baaffc77642f2db3b1749d3634f9b5a19d14"
   integrity sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:


### PR DESCRIPTION
## 問題
GitHub Actions の `yarn install --frozen-lockfile` が以下で失敗:

\`\`\`
error Error: getaddrinfo ENOTFOUND edge.artifactory.corp.yahoo.co.jp
\`\`\`

## 原因
直前の PR #52 で `yarn add gsap` を実行した際、開発端末がコーポレート（Yahoo）ネットワーク下にあり、yarn の registry が社内 Artifactory（`edge.artifactory.corp.yahoo.co.jp:8000`）に向いていた結果、`yarn.lock` の gsap エントリの `resolved` URL がプライベートミラーになっていた。Actions ランナーからは社内 DNS が引けず install で落ちる。

## 修正
- `yarn.lock` の gsap エントリの `resolved` を `https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz#7851baa...` に書き換え
- tarball の sha1（URL 末尾）と integrity sha512 は同一のため、検証は通る
- 他のパッケージは元々 `registry.npmjs.org` 解決済みで影響なし

## 検証
- [x] `yarn.lock` に `edge.artifactory.corp.yahoo.co.jp` の残りなし
- [ ] PR 上の CI（yarn install + build）の成功を確認

## 再発防止メモ
今後 `yarn add` を実行する際は、本リポジトリのカレントディレクトリで registry が public に向いていることを確認する。例:

\`\`\`
yarn config get registry  # → https://registry.npmjs.org/ を期待
\`\`\`

社内 .npmrc / .yarnrc が `~` 配下にあると上書きされるので、必要に応じて `--registry https://registry.npmjs.org/` を明示する。