### PR TITLE
feat: My Works のカードに reactbits.dev の ElectricBorder を適用

### DIFF
--- a/src/components/ElectricBorder/ElectricBorder.css
+++ b/src/components/ElectricBorder/ElectricBorder.css
@@ -1,0 +1,62 @@
+.electric-border {
+  --electric-light-color: oklch(from var(--electric-border-color) l c h);
+  position: relative;
+  border-radius: inherit;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.eb-canvas-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.eb-canvas {
+  display: block;
+}
+
+.eb-content {
+  position: relative;
+  border-radius: inherit;
+  z-index: 1;
+}
+
+.eb-layers {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.eb-glow-1,
+.eb-glow-2,
+.eb-background-glow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.eb-glow-1 {
+  border: 2px solid oklch(from var(--electric-border-color) l c h / 0.6);
+  filter: blur(1px);
+}
+
+.eb-glow-2 {
+  border: 2px solid var(--electric-light-color);
+  filter: blur(4px);
+}
+
+.eb-background-glow {
+  z-index: -1;
+  transform: scale(1.1);
+  filter: blur(32px);
+  opacity: 0.3;
+  background: linear-gradient(-30deg, var(--electric-light-color), transparent, var(--electric-border-color));
+}

--- a/src/components/ElectricBorder/ElectricBorder.tsx
+++ b/src/components/ElectricBorder/ElectricBorder.tsx
@@ -1,0 +1,305 @@
+import React, { useEffect, useRef, useCallback, CSSProperties, ReactNode } from 'react';
+import './ElectricBorder.css';
+
+interface ElectricBorderProps {
+  children?: ReactNode;
+  color?: string;
+  speed?: number;
+  chaos?: number;
+  borderRadius?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const ElectricBorder: React.FC<ElectricBorderProps> = ({
+  children,
+  color = '#5227FF',
+  speed = 1,
+  chaos = 0.12,
+  borderRadius = 24,
+  className,
+  style
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<number | null>(null);
+  const timeRef = useRef(0);
+  const lastFrameTimeRef = useRef(0);
+
+  const random = useCallback((x: number): number => {
+    return (Math.sin(x * 12.9898) * 43758.5453) % 1;
+  }, []);
+
+  const noise2D = useCallback(
+    (x: number, y: number): number => {
+      const i = Math.floor(x);
+      const j = Math.floor(y);
+      const fx = x - i;
+      const fy = y - j;
+
+      const a = random(i + j * 57);
+      const b = random(i + 1 + j * 57);
+      const c = random(i + (j + 1) * 57);
+      const d = random(i + 1 + (j + 1) * 57);
+
+      const ux = fx * fx * (3.0 - 2.0 * fx);
+      const uy = fy * fy * (3.0 - 2.0 * fy);
+
+      return a * (1 - ux) * (1 - uy) + b * ux * (1 - uy) + c * (1 - ux) * uy + d * ux * uy;
+    },
+    [random]
+  );
+
+  const octavedNoise = useCallback(
+    (
+      x: number,
+      octaves: number,
+      lacunarity: number,
+      gain: number,
+      baseAmplitude: number,
+      baseFrequency: number,
+      time: number,
+      seed: number,
+      baseFlatness: number
+    ): number => {
+      let y = 0;
+      let amplitude = baseAmplitude;
+      let frequency = baseFrequency;
+
+      for (let i = 0; i < octaves; i++) {
+        let octaveAmplitude = amplitude;
+        if (i === 0) {
+          octaveAmplitude *= baseFlatness;
+        }
+        y += octaveAmplitude * noise2D(frequency * x + seed * 100, time * frequency * 0.3);
+        frequency *= lacunarity;
+        amplitude *= gain;
+      }
+
+      return y;
+    },
+    [noise2D]
+  );
+
+  const getCornerPoint = useCallback(
+    (
+      centerX: number,
+      centerY: number,
+      radius: number,
+      startAngle: number,
+      arcLength: number,
+      progress: number
+    ): { x: number; y: number } => {
+      const angle = startAngle + progress * arcLength;
+      return {
+        x: centerX + radius * Math.cos(angle),
+        y: centerY + radius * Math.sin(angle)
+      };
+    },
+    []
+  );
+
+  const getRoundedRectPoint = useCallback(
+    (t: number, left: number, top: number, width: number, height: number, radius: number): { x: number; y: number } => {
+      const straightWidth = width - 2 * radius;
+      const straightHeight = height - 2 * radius;
+      const cornerArc = (Math.PI * radius) / 2;
+      const totalPerimeter = 2 * straightWidth + 2 * straightHeight + 4 * cornerArc;
+      const distance = t * totalPerimeter;
+
+      let accumulated = 0;
+
+      if (distance <= accumulated + straightWidth) {
+        const progress = (distance - accumulated) / straightWidth;
+        return { x: left + radius + progress * straightWidth, y: top };
+      }
+      accumulated += straightWidth;
+
+      if (distance <= accumulated + cornerArc) {
+        const progress = (distance - accumulated) / cornerArc;
+        return getCornerPoint(left + width - radius, top + radius, radius, -Math.PI / 2, Math.PI / 2, progress);
+      }
+      accumulated += cornerArc;
+
+      if (distance <= accumulated + straightHeight) {
+        const progress = (distance - accumulated) / straightHeight;
+        return { x: left + width, y: top + radius + progress * straightHeight };
+      }
+      accumulated += straightHeight;
+
+      if (distance <= accumulated + cornerArc) {
+        const progress = (distance - accumulated) / cornerArc;
+        return getCornerPoint(left + width - radius, top + height - radius, radius, 0, Math.PI / 2, progress);
+      }
+      accumulated += cornerArc;
+
+      if (distance <= accumulated + straightWidth) {
+        const progress = (distance - accumulated) / straightWidth;
+        return { x: left + width - radius - progress * straightWidth, y: top + height };
+      }
+      accumulated += straightWidth;
+
+      if (distance <= accumulated + cornerArc) {
+        const progress = (distance - accumulated) / cornerArc;
+        return getCornerPoint(left + radius, top + height - radius, radius, Math.PI / 2, Math.PI / 2, progress);
+      }
+      accumulated += cornerArc;
+
+      if (distance <= accumulated + straightHeight) {
+        const progress = (distance - accumulated) / straightHeight;
+        return { x: left, y: top + height - radius - progress * straightHeight };
+      }
+      accumulated += straightHeight;
+
+      const progress = (distance - accumulated) / cornerArc;
+      return getCornerPoint(left + radius, top + radius, radius, Math.PI, Math.PI / 2, progress);
+    },
+    [getCornerPoint]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const octaves = 10;
+    const lacunarity = 1.6;
+    const gain = 0.7;
+    const amplitude = chaos;
+    const frequency = 10;
+    const baseFlatness = 0;
+    const displacement = 60;
+    const borderOffset = 60;
+
+    const updateSize = () => {
+      const rect = container.getBoundingClientRect();
+      const width = rect.width + borderOffset * 2;
+      const height = rect.height + borderOffset * 2;
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.scale(dpr, dpr);
+
+      return { width, height };
+    };
+
+    let { width, height } = updateSize();
+
+    const drawElectricBorder = (currentTime: number) => {
+      if (!canvas || !ctx) return;
+
+      const deltaTime = (currentTime - lastFrameTimeRef.current) / 1000;
+      timeRef.current += deltaTime * speed;
+      lastFrameTimeRef.current = currentTime;
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(dpr, dpr);
+
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+
+      const scale = displacement;
+      const left = borderOffset;
+      const top = borderOffset;
+      const borderWidth = width - 2 * borderOffset;
+      const borderHeight = height - 2 * borderOffset;
+      const maxRadius = Math.min(borderWidth, borderHeight) / 2;
+      const radius = Math.min(borderRadius, maxRadius);
+
+      const approximatePerimeter = 2 * (borderWidth + borderHeight) + 2 * Math.PI * radius;
+      const sampleCount = Math.floor(approximatePerimeter / 2);
+
+      ctx.beginPath();
+
+      for (let i = 0; i <= sampleCount; i++) {
+        const progress = i / sampleCount;
+
+        const point = getRoundedRectPoint(progress, left, top, borderWidth, borderHeight, radius);
+
+        const xNoise = octavedNoise(
+          progress * 8,
+          octaves,
+          lacunarity,
+          gain,
+          amplitude,
+          frequency,
+          timeRef.current,
+          0,
+          baseFlatness
+        );
+        const yNoise = octavedNoise(
+          progress * 8,
+          octaves,
+          lacunarity,
+          gain,
+          amplitude,
+          frequency,
+          timeRef.current,
+          1,
+          baseFlatness
+        );
+
+        const displacedX = point.x + xNoise * scale;
+        const displacedY = point.y + yNoise * scale;
+
+        if (i === 0) {
+          ctx.moveTo(displacedX, displacedY);
+        } else {
+          ctx.lineTo(displacedX, displacedY);
+        }
+      }
+
+      ctx.closePath();
+      ctx.stroke();
+
+      animationRef.current = requestAnimationFrame(drawElectricBorder);
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      const newSize = updateSize();
+      width = newSize.width;
+      height = newSize.height;
+    });
+    resizeObserver.observe(container);
+
+    animationRef.current = requestAnimationFrame(drawElectricBorder);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      resizeObserver.disconnect();
+    };
+  }, [color, speed, chaos, borderRadius, octavedNoise, getRoundedRectPoint]);
+
+  const vars = {
+    '--electric-border-color': color,
+    borderRadius
+  } as CSSProperties;
+
+  return (
+    <div ref={containerRef} className={`electric-border ${className ?? ''}`} style={{ ...vars, ...style }}>
+      <div className="eb-canvas-container">
+        <canvas ref={canvasRef} className="eb-canvas" />
+      </div>
+      <div className="eb-layers">
+        <div className="eb-glow-1" />
+        <div className="eb-glow-2" />
+        <div className="eb-background-glow" />
+      </div>
+      <div className="eb-content">{children}</div>
+    </div>
+  );
+};
+
+export default ElectricBorder;

--- a/src/components/ElectricBorder/ElectricBorder.tsx
+++ b/src/components/ElectricBorder/ElectricBorder.tsx
@@ -171,8 +171,8 @@ const ElectricBorder: React.FC<ElectricBorderProps> = ({
     const amplitude = chaos;
     const frequency = 10;
     const baseFlatness = 0;
-    const displacement = 60;
-    const borderOffset = 60;
+    const displacement = 24;
+    const borderOffset = 28;
 
     const updateSize = () => {
       const rect = container.getBoundingClientRect();

--- a/src/components/ElectricBorder/index.ts
+++ b/src/components/ElectricBorder/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ElectricBorder";

--- a/src/components/WorkItem/WorkItem.css
+++ b/src/components/WorkItem/WorkItem.css
@@ -6,7 +6,7 @@
 
 #work .work-item {
   box-sizing: border-box;
-  padding: 5px;
+  padding: 16px;
   width: 33.3%;
   min-width: 333px;
   text-align: center;
@@ -16,9 +16,20 @@
   padding: 50px;
 }
 
+#work .work-item__border {
+  display: block;
+  border-radius: 10px;
+}
+
 #work figure {
   margin: 0;
   position: relative;
+  border-radius: 10px;
+}
+
+#work figure img {
+  border-radius: 10px;
+  display: block;
 }
 
 #work figcaption {

--- a/src/components/WorkItem/WorkItem.tsx
+++ b/src/components/WorkItem/WorkItem.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ElectricBorder from "../ElectricBorder";
 import "./WorkItem.css";
 
 type WorkItemProps = {
@@ -19,43 +20,51 @@ const WorkItem: React.FC<WorkItemProps> = ({
   duration,
   link,
   disabled = false,
-}) => (
-  <li className={`work-item ${disabled ? 'disabled-item' : ''}`}>
-    <figure>
-      {disabled ? (
-        <div className="disabled-link-container">
-          <img src={imgSrc} alt={imgAlt} />
-          <div className="disabled-overlay">
-            <span>
-              Coming Soon
-            </span>
-          </div>
-          <figcaption>
-            <div className="fig-inner">
-              <h3>{title}</h3>
-              <p>{description}</p>
-              <p>制作期間: {duration}</p>
+}) => {
+  const borderColor = disabled ? "#7a7a7a" : "#00d8ff";
+  const borderSpeed = disabled ? 0.4 : 1;
+  const borderChaos = disabled ? 0.2 : 0.5;
+
+  return (
+    <li className={`work-item ${disabled ? "disabled-item" : ""}`}>
+      <ElectricBorder
+        color={borderColor}
+        speed={borderSpeed}
+        chaos={borderChaos}
+        borderRadius={10}
+        className="work-item__border"
+      >
+        <figure>
+          {disabled ? (
+            <div className="disabled-link-container">
+              <img src={imgSrc} alt={imgAlt} />
+              <div className="disabled-overlay">
+                <span>Coming Soon</span>
+              </div>
+              <figcaption>
+                <div className="fig-inner">
+                  <h3>{title}</h3>
+                  <p>{description}</p>
+                  <p>制作期間: {duration}</p>
+                </div>
+              </figcaption>
             </div>
-          </figcaption>
-        </div>
-      ) : (
-        <a 
-          href={link} 
-          target="_blank" 
-          rel="noopener noreferrer"
-        >
-          <img src={imgSrc} alt={imgAlt} />
-          <figcaption>
-            <div className="fig-inner">
-              <h3>{title}</h3>
-              <p>{description}</p>
-              <p>制作期間: {duration}</p>
-            </div>
-          </figcaption>
-        </a>
-      )}
-    </figure>
-  </li>
-);
+          ) : (
+            <a href={link} target="_blank" rel="noopener noreferrer">
+              <img src={imgSrc} alt={imgAlt} />
+              <figcaption>
+                <div className="fig-inner">
+                  <h3>{title}</h3>
+                  <p>{description}</p>
+                  <p>制作期間: {duration}</p>
+                </div>
+              </figcaption>
+            </a>
+          )}
+        </figure>
+      </ElectricBorder>
+    </li>
+  );
+};
 
 export default WorkItem;

--- a/src/components/WorkItem/WorkItem.tsx
+++ b/src/components/WorkItem/WorkItem.tsx
@@ -22,8 +22,8 @@ const WorkItem: React.FC<WorkItemProps> = ({
   disabled = false,
 }) => {
   const borderColor = disabled ? "#7a7a7a" : "#00d8ff";
-  const borderSpeed = disabled ? 0.4 : 1;
-  const borderChaos = disabled ? 0.2 : 0.5;
+  const borderSpeed = disabled ? 0.4 : 0.8;
+  const borderChaos = disabled ? 0.08 : 0.18;
 
   return (
     <li className={`work-item ${disabled ? "disabled-item" : ""}`}>


### PR DESCRIPTION
Closes #54

## 概要
Works セクションの各カードに reactbits.dev の **ElectricBorder** を適用。canvas + glow レイヤーで、ボーダー周囲に電気的な揺らぎ演出を施し、Works セクションの視覚インパクトを上げる。

## 変更内容

### ElectricBorder の取り込み
- `src/components/ElectricBorder/` に reactbits 版（TSX + CSS）を配置
  - 元ソース: `DavidHDev/react-bits` (ts-default)
  - 改変なし
- CSS は `oklch(from ...)` 相対色構文を使用
  - 対応: Chrome 119+ / Firefox 113+ / Safari 16.4+

### WorkItem の改修
- `<figure>` を `<ElectricBorder>` でラップ
- props はカードの状態で出し分け:
  | 状態 | color | speed | chaos |
  |---|---|---|---|
  | 通常 | `#00d8ff`（サイバートーン） | 1 | 0.5 |
  | disabled | `#7a7a7a`（グレー） | 0.4 | 0.2 |
- `borderRadius={10}` で角丸を統一

### CSS 調整 (`WorkItem.css`)
- `.work-item` の padding を 5px → 16px に拡大。glow（borderOffset = 60px）が隣カードと過度に重なるのを軽減
- `.work-item__border` / `figure` / `img` に `border-radius: 10px` を付与し、ElectricBorder の角丸と視覚的に整合

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功（バンドルサイズ: +3KB gzip 程度）
- [ ] ブラウザ目視:
  - [ ] 全 Works カードにアニメーションするボーダーが表示される
  - [ ] hover で figcaption がピンクオーバーレイになる演出が壊れていない
  - [ ] disabled カードは控えめなボーダー + Coming Soon が見える
  - [ ] PC / SP（375 / 768 等）でレイアウト破綻なし

## パフォーマンスメモ
- 各カードごとに canvas + requestAnimationFrame が回るため、12 カードあると 12 ループ。実機で重くなるようなら別 Issue で IntersectionObserver による画面内駆動最適化を検討
- canvas の DPR は最大 2 にキャップ済み（既定実装）

## アウトオブスコープ
- Works データ追加 / 並び替え
- 全カードで色を変える等のカスタマイズ
- 古いブラウザ向けの `oklch(from ...)` フォールバック