### PR TITLE
feat: TopFv 限定だった背景アニメ (Aurora + Particles) をページ全体に拡張

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import HomePage from "./components/HomePage";
 import Footer from "./components/Footer";
 import Contact from "./components/Contact";
 import TargetCursor from "./components/TargetCursor";
+import SiteBackground from "./components/SiteBackground";
 
 // グローバルスタイルを作成
 const GlobalStyle = createGlobalStyle`
@@ -22,7 +23,7 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.7;
     margin: 0;
     color: #f6f6e9;
-    background-color: rgba(28, 28, 28, 1);
+    background-color: transparent;
   }
   .wrapper {
     box-sizing:border-box;
@@ -44,6 +45,7 @@ const App: React.FC = () => {
   return (
   <>
     <GlobalStyle />
+    <SiteBackground />
     <TargetCursor targetSelector=".cursor-target" />
     <div className="App">
       <Header />

--- a/src/components/SiteBackground/SiteBackground.css
+++ b/src/components/SiteBackground/SiteBackground.css
@@ -1,0 +1,26 @@
+.site-background {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  pointer-events: none;
+  overflow: hidden;
+  background-color: rgba(28, 28, 28, 1);
+}
+
+.site-background__aurora {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+}
+
+.site-background__particles {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+}

--- a/src/components/SiteBackground/SiteBackground.tsx
+++ b/src/components/SiteBackground/SiteBackground.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useRef } from 'react';
+import { Renderer, Program, Mesh, Color, Triangle } from 'ogl';
+import Particles from '../Particles';
+import './SiteBackground.css';
+
+const VERT = `#version 300 es
+in vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+const FRAG = `#version 300 es
+precision highp float;
+
+uniform float uTime;
+uniform float uAmplitude;
+uniform vec3 uColorStops[3];
+uniform vec2 uResolution;
+uniform float uBlend;
+
+out vec4 fragColor;
+
+vec3 permute(vec3 x) {
+  return mod(((x * 34.0) + 1.0) * x, 289.0);
+}
+
+float snoise(vec2 v){
+  const vec4 C = vec4(
+      0.211324865405187, 0.366025403784439,
+      -0.577350269189626, 0.024390243902439
+  );
+  vec2 i  = floor(v + dot(v, C.yy));
+  vec2 x0 = v - i + dot(i, C.xx);
+  vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+  vec4 x12 = x0.xyxy + C.xxzz;
+  x12.xy -= i1;
+  i = mod(i, 289.0);
+
+  vec3 p = permute(
+      permute(i.y + vec3(0.0, i1.y, 1.0))
+    + i.x + vec3(0.0, i1.x, 1.0)
+  );
+
+  vec3 m = max(
+      0.5 - vec3(
+          dot(x0, x0),
+          dot(x12.xy, x12.xy),
+          dot(x12.zw, x12.zw)
+      ),
+      0.0
+  );
+  m = m * m;
+  m = m * m;
+
+  vec3 x = 2.0 * fract(p * C.www) - 1.0;
+  vec3 h = abs(x) - 0.5;
+  vec3 ox = floor(x + 0.5);
+  vec3 a0 = x - ox;
+  m *= 1.79284291400159 - 0.85373472095314 * (a0*a0 + h*h);
+
+  vec3 g;
+  g.x  = a0.x  * x0.x  + h.x  * x0.y;
+  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+  return 130.0 * dot(m, g);
+}
+
+struct ColorStop {
+  vec3 color;
+  float position;
+};
+
+#define COLOR_RAMP(colors, factor, finalColor) {              \
+  int index = 0;                                            \
+  for (int i = 0; i < 2; i++) {                               \
+     ColorStop currentColor = colors[i];                    \
+     bool isInBetween = currentColor.position <= factor;    \
+     index = int(mix(float(index), float(i), float(isInBetween))); \
+  }                                                         \
+  ColorStop currentColor = colors[index];                   \
+  ColorStop nextColor = colors[index + 1];                  \
+  float range = nextColor.position - currentColor.position; \
+  float lerpFactor = (factor - currentColor.position) / range; \
+  finalColor = mix(currentColor.color, nextColor.color, lerpFactor); \
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+
+  ColorStop colors[3];
+  colors[0] = ColorStop(uColorStops[0], 0.0);
+  colors[1] = ColorStop(uColorStops[1], 0.5);
+  colors[2] = ColorStop(uColorStops[2], 1.0);
+
+  vec3 rampColor;
+  COLOR_RAMP(colors, uv.x, rampColor);
+
+  float height = snoise(vec2(uv.x * 2.0 + uTime * 0.1, uTime * 0.25)) * 0.5 * uAmplitude;
+  height = exp(height);
+  height = (uv.y * 2.0 - height + 0.2);
+  float intensity = 0.6 * height;
+
+  float midPoint = 0.20;
+  float auroraAlpha = smoothstep(midPoint - uBlend * 0.5, midPoint + uBlend * 0.5, intensity);
+
+  vec3 auroraColor = intensity * rampColor;
+
+  fragColor = vec4(auroraColor * auroraAlpha, auroraAlpha);
+}
+`;
+
+interface SiteBackgroundProps {
+  colorStops?: string[];
+  amplitude?: number;
+  blend?: number;
+  speed?: number;
+}
+
+const SiteBackground: React.FC<SiteBackgroundProps> = ({
+  colorStops = ['#00d8ff', '#7cff67', '#00d8ff'],
+  amplitude = 1.0,
+  blend = 0.5,
+  speed = 1.0,
+}) => {
+  const ctnDom = useRef<HTMLDivElement>(null);
+  const propsRef = useRef({ colorStops, amplitude, blend, speed });
+  propsRef.current = { colorStops, amplitude, blend, speed };
+
+  useEffect(() => {
+    const ctn = ctnDom.current;
+    if (!ctn) return;
+
+    const renderer = new Renderer({
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: true,
+    });
+    const gl = renderer.gl;
+    gl.clearColor(0, 0, 0, 0);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    gl.canvas.style.backgroundColor = 'transparent';
+
+    let program: Program;
+
+    const resize = () => {
+      if (!ctn) return;
+      const width = ctn.offsetWidth;
+      const height = ctn.offsetHeight;
+      renderer.setSize(width, height);
+      if (program) {
+        program.uniforms.uResolution.value = [width, height];
+      }
+    };
+    window.addEventListener('resize', resize);
+
+    const geometry = new Triangle(gl);
+    if (geometry.attributes.uv) {
+      delete geometry.attributes.uv;
+    }
+
+    const colorStopsArray = propsRef.current.colorStops.map((hex: string) => {
+      const c = new Color(hex);
+      return [c.r, c.g, c.b];
+    });
+
+    program = new Program(gl, {
+      vertex: VERT,
+      fragment: FRAG,
+      uniforms: {
+        uTime: { value: 0 },
+        uAmplitude: { value: propsRef.current.amplitude },
+        uColorStops: { value: colorStopsArray },
+        uResolution: { value: [ctn.offsetWidth, ctn.offsetHeight] },
+        uBlend: { value: propsRef.current.blend },
+      },
+    });
+
+    const mesh = new Mesh(gl, { geometry, program });
+    ctn.appendChild(gl.canvas as HTMLCanvasElement);
+
+    let animateId = 0;
+    const update = (t: number) => {
+      animateId = requestAnimationFrame(update);
+      const time = t * 0.01;
+      const currentSpeed = propsRef.current.speed;
+      program.uniforms.uTime.value = time * currentSpeed * 0.1;
+      program.uniforms.uAmplitude.value = propsRef.current.amplitude;
+      program.uniforms.uBlend.value = propsRef.current.blend;
+      const stops = propsRef.current.colorStops;
+      program.uniforms.uColorStops.value = stops.map((hex: string) => {
+        const c = new Color(hex);
+        return [c.r, c.g, c.b];
+      });
+      renderer.render({ scene: mesh });
+    };
+    animateId = requestAnimationFrame(update);
+
+    resize();
+
+    return () => {
+      cancelAnimationFrame(animateId);
+      window.removeEventListener('resize', resize);
+      if (ctn && gl.canvas.parentNode === ctn) {
+        ctn.removeChild(gl.canvas as HTMLCanvasElement);
+      }
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+  }, []);
+
+  return (
+    <div className="site-background" aria-hidden="true">
+      <div ref={ctnDom} className="site-background__aurora" />
+      <div className="site-background__particles">
+        <Particles
+          particleColors={['#ffffff', '#ffffff']}
+          particleCount={400}
+          particleSpread={15}
+          speed={0.2}
+          particleBaseSize={100}
+          moveParticlesOnHover={true}
+          alphaParticles={false}
+          disableRotation={false}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SiteBackground;

--- a/src/components/SiteBackground/index.ts
+++ b/src/components/SiteBackground/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SiteBackground";

--- a/src/components/TopFv/Aurora.css
+++ b/src/components/TopFv/Aurora.css
@@ -10,36 +10,6 @@
   align-items: center;
 }
 
-.aurora-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 0;
-}
-
-.fuzzy-text-container {
-  position: absolute;
-  z-index: 10;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  padding: 0 20px;
-  box-sizing: border-box;
-  text-align: center;
-}
-
-.fuzzy-text-container canvas,
-.fuzzy-text {
-  pointer-events: auto;
-  max-width: 100%;
-  touch-action: auto;
-}
-
 /* GlitchTextのカスタムクラス */
 .glitch-desktop {
   font-size: clamp(4rem, 12vw, 12rem);
@@ -133,15 +103,6 @@ html, body {
   .topfv-container {
     height: -webkit-fill-available;
   }
-}
-
-.particles-background {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
 }
 
 .portfolio-title {

--- a/src/components/TopFv/TopFv.tsx
+++ b/src/components/TopFv/TopFv.tsx
@@ -1,152 +1,21 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Renderer, Program, Mesh, Color, Triangle } from "ogl";
+import React, { useState, useEffect } from 'react';
 import GlitchText from '../GlitchText';
 import DecryptedLoader from '../DecryptedLoader';
 import ViewportHandler from '../ViewportHandler';
-import Particles from '../Particles';
 import { useViewport } from '../../hooks/useViewport';
 
 import './Aurora.css';
 
-const VERT = `#version 300 es
-in vec2 position;
-void main() {
-  gl_Position = vec4(position, 0.0, 1.0);
-}
-`;
-
-const FRAG = `#version 300 es
-precision highp float;
-
-uniform float uTime;
-uniform float uAmplitude;
-uniform vec3 uColorStops[3];
-uniform vec2 uResolution;
-uniform float uBlend;
-
-out vec4 fragColor;
-
-vec3 permute(vec3 x) {
-  return mod(((x * 34.0) + 1.0) * x, 289.0);
-}
-
-float snoise(vec2 v){
-  const vec4 C = vec4(
-      0.211324865405187, 0.366025403784439,
-      -0.577350269189626, 0.024390243902439
-  );
-  vec2 i  = floor(v + dot(v, C.yy));
-  vec2 x0 = v - i + dot(i, C.xx);
-  vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
-  vec4 x12 = x0.xyxy + C.xxzz;
-  x12.xy -= i1;
-  i = mod(i, 289.0);
-
-  vec3 p = permute(
-      permute(i.y + vec3(0.0, i1.y, 1.0))
-    + i.x + vec3(0.0, i1.x, 1.0)
-  );
-
-  vec3 m = max(
-      0.5 - vec3(
-          dot(x0, x0),
-          dot(x12.xy, x12.xy),
-          dot(x12.zw, x12.zw)
-      ), 
-      0.0
-  );
-  m = m * m;
-  m = m * m;
-
-  vec3 x = 2.0 * fract(p * C.www) - 1.0;
-  vec3 h = abs(x) - 0.5;
-  vec3 ox = floor(x + 0.5);
-  vec3 a0 = x - ox;
-  m *= 1.79284291400159 - 0.85373472095314 * (a0*a0 + h*h);
-
-  vec3 g;
-  g.x  = a0.x  * x0.x  + h.x  * x0.y;
-  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
-  return 130.0 * dot(m, g);
-}
-
-struct ColorStop {
-  vec3 color;
-  float position;
-};
-
-#define COLOR_RAMP(colors, factor, finalColor) {              \
-  int index = 0;                                            \
-  for (int i = 0; i < 2; i++) {                               \
-     ColorStop currentColor = colors[i];                    \
-     bool isInBetween = currentColor.position <= factor;    \
-     index = int(mix(float(index), float(i), float(isInBetween))); \
-  }                                                         \
-  ColorStop currentColor = colors[index];                   \
-  ColorStop nextColor = colors[index + 1];                  \
-  float range = nextColor.position - currentColor.position; \
-  float lerpFactor = (factor - currentColor.position) / range; \
-  finalColor = mix(currentColor.color, nextColor.color, lerpFactor); \
-}
-
-void main() {
-  vec2 uv = gl_FragCoord.xy / uResolution;
-  
-  ColorStop colors[3];
-  colors[0] = ColorStop(uColorStops[0], 0.0);
-  colors[1] = ColorStop(uColorStops[1], 0.5);
-  colors[2] = ColorStop(uColorStops[2], 1.0);
-  
-  vec3 rampColor;
-  COLOR_RAMP(colors, uv.x, rampColor);
-  
-  float height = snoise(vec2(uv.x * 2.0 + uTime * 0.1, uTime * 0.25)) * 0.5 * uAmplitude;
-  height = exp(height);
-  height = (uv.y * 2.0 - height + 0.2);
-  float intensity = 0.6 * height;
-  
-  // midPoint is fixed; uBlend controls the transition width.
-  float midPoint = 0.20;
-  float auroraAlpha = smoothstep(midPoint - uBlend * 0.5, midPoint + uBlend * 0.5, intensity);
-  
-  vec3 auroraColor = intensity * rampColor;
-  
-  // Premultiplied alpha output.
-  fragColor = vec4(auroraColor * auroraAlpha, auroraAlpha);
-}
-`;
-
-interface TopFvProps {
-  colorStops?: string[];
-  amplitude?: number;
-  blend?: number;
-  time?: number;
-  speed?: number;
-}
-
-const TopFv: React.FC<TopFvProps> = (props) => {
-  const {
-    colorStops = ["#00d8ff", "#7cff67", "#00d8ff"],
-    amplitude = 1.0,
-    blend = 0.5
-  } = props;
-  
+const TopFv: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [contentVisible, setContentVisible] = useState(false);
   const { width: viewportWidth, isMobile } = useViewport();
 
-  const propsRef = useRef<TopFvProps>(props);
-  propsRef.current = props;
-
-  const ctnDom = useRef<HTMLDivElement>(null);
-
-  // Simulate asset loading
   useEffect(() => {
-    // Simulate resources loading
     const timer = setTimeout(() => {
       setIsLoading(false);
     }, 2000);
-    
+
     return () => clearTimeout(timer);
   }, []);
 
@@ -154,89 +23,6 @@ const TopFv: React.FC<TopFvProps> = (props) => {
     setContentVisible(true);
   };
 
-  useEffect(() => {
-    const ctn = ctnDom.current;
-    if (!ctn || isLoading) return;
-
-    const renderer = new Renderer({
-      alpha: true,
-      premultipliedAlpha: true,
-      antialias: true
-    });
-    const gl = renderer.gl;
-    gl.clearColor(0, 0, 0, 0);
-    gl.enable(gl.BLEND);
-    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-    gl.canvas.style.backgroundColor = 'transparent';
-
-    let program: Program;
-
-    function resize() {
-      if (!ctn) return;
-      const width = ctn.offsetWidth;
-      const height = ctn.offsetHeight;
-      renderer.setSize(width, height);
-      if (program) {
-        program.uniforms.uResolution.value = [width, height];
-      }
-    }
-    window.addEventListener("resize", resize);
-
-    const geometry = new Triangle(gl);
-    if (geometry.attributes.uv) {
-      delete geometry.attributes.uv;
-    }
-
-    const colorStopsArray = colorStops.map((hex: string) => {
-      const c = new Color(hex);
-      return [c.r, c.g, c.b];
-    });
-
-    program = new Program(gl, {
-      vertex: VERT,
-      fragment: FRAG,
-      uniforms: {
-        uTime: { value: 0 },
-        uAmplitude: { value: amplitude },
-        uColorStops: { value: colorStopsArray },
-        uResolution: { value: [ctn.offsetWidth, ctn.offsetHeight] },
-        uBlend: { value: blend }
-      }
-    });
-
-    const mesh = new Mesh(gl, { geometry, program });
-    ctn.appendChild(gl.canvas as HTMLCanvasElement);
-
-    let animateId = 0;
-    const update = (t: number) => {
-      animateId = requestAnimationFrame(update);
-      const { time = t * 0.01, speed = 1.0 } = propsRef.current;
-      program.uniforms.uTime.value = time * speed * 0.1;
-      program.uniforms.uAmplitude.value = propsRef.current.amplitude ?? 1.0;
-      program.uniforms.uBlend.value = propsRef.current.blend ?? blend;
-      const stops = propsRef.current.colorStops ?? colorStops;
-      program.uniforms.uColorStops.value = stops.map((hex: string) => {
-        const c = new Color(hex);
-        return [c.r, c.g, c.b];
-      });
-      renderer.render({ scene: mesh });
-    };
-    animateId = requestAnimationFrame(update);
-
-    resize();
-
-    return () => {
-      cancelAnimationFrame(animateId);
-      window.removeEventListener("resize", resize);
-      if (ctn && gl.canvas.parentNode === ctn) {
-        ctn.removeChild(gl.canvas as HTMLCanvasElement);
-      }
-      gl.getExtension("WEBGL_lose_context")?.loseContext();
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amplitude, isLoading]);
-  
-  // getCustomGlitchClass関数を作成して、モバイルかどうかに応じてクラスを変更
   const getCustomGlitchClass = () => {
     if (isMobile) {
       if (viewportWidth < 375) {
@@ -249,30 +35,16 @@ const TopFv: React.FC<TopFvProps> = (props) => {
     }
     return 'glitch-desktop';
   };
-  
-  // getGlitchSpeed関数を作成して、モバイルかどうかに応じてスピードを変更
+
   const getGlitchSpeed = () => {
     return isMobile ? 1.5 : 1;
   };
-  
+
   return (
     <>
       <ViewportHandler />
       <DecryptedLoader isLoading={isLoading} onLoadingComplete={handleLoadingComplete} />
       <div className={`topfv-container ${contentVisible ? 'fade-in' : 'hidden'}`}>
-        <div className="particles-background">
-          <Particles
-            particleColors={['#ffffff', '#ffffff']}
-            particleCount={400}
-            particleSpread={15}
-            speed={0.2}
-            particleBaseSize={100}
-            moveParticlesOnHover={true}
-            alphaParticles={false}
-            disableRotation={false}
-          />
-        </div>
-        
         <div className="portfolio-title">
           <GlitchText
             speed={getGlitchSpeed()}


### PR DESCRIPTION
Closes #56

## 概要
これまで `TopFv` の `.topfv-container`（100vh）内にしか描画されていなかった Aurora シェーダー + Particles を、サイト全体の固定背景として常時表示するように切り出し。スクロールしても背景アニメが viewport に追従し、Header から Footer まで見えるようになる。

## 変更内容

### 新規: `src/components/SiteBackground/`
- 現 `TopFv.tsx` の WebGL Aurora 実装（`VERT` / `FRAG` GLSL、`Renderer` / `Program` / `Mesh` セットアップ）をそのまま移植
- 同コンポーネント内で `<Particles />` も配置（粒子設定は既存維持）
- ルートは `position: fixed; inset: 0; z-index: -1; pointer-events: none`
- フォールバックの単色 `rgba(28, 28, 28, 1)` を base に保持し、シェーダー未対応環境でも真っ黒にならないように

### `App.tsx`
- `<SiteBackground />` を `GlobalStyle` 直後に 1 つだけマウント
- `body { background-color: rgba(28, 28, 28, 1) }` を `transparent` に変更し、`SiteBackground` の canvas が透けて見えるように

### `TopFv.tsx`
- 背景関連の責務を全て撤去:
  - `VERT` / `FRAG` GLSL 定数
  - Aurora の `useEffect`（Renderer 初期化～破棄）
  - `<Particles />` JSX と `.particles-background` ラッパー
  - `ogl` (`Renderer` / `Program` / `Mesh` / `Color` / `Triangle`) と `Particles` の import
  - `TopFvProps` インターフェース（背景パラメータは SiteBackground 側で管理）
- DecryptedLoader + GlitchText + `portfolio-title` 位置決めに専念

### `Aurora.css`
- 未参照になった `.aurora-container` / `.fuzzy-text-container` / `.particles-background` を削除

## 動作（期待）
- 初回読み込み: DecryptedLoader（黒幕 + 復号テキスト）がフルスクリーンを覆う → 完了でフェードアウト
- TopFv セクション: Aurora + Particles が背景に動く（変更前と同じ見た目）
- スクロール後の各セクション: 不透明な背景を持つ要素（後述）以外は Aurora が透けて見える

## 既知の留意点
セクション単位の背景色は今回は触っていません。以下は不透明なので、その範囲では Aurora が見えません。必要に応じて別 PR で半透明化を検討:

| 箇所 | 現状 |
|---|---|
| `.wrapper` (MySkills 周辺) | `background: #fff` |
| `Contact` セクション | `background-color: #808080` |
| `WorkItem` の `.disabled-item figure` | `background-color: #f0f0f0` |

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功
- [ ] ブラウザ目視:
  - [ ] ページ最上部から最下部までスクロールしても Aurora + Particles が viewport に追従して見える
  - [ ] TopFv のタイトル / DecryptedLoader 遷移が壊れていない
  - [ ] TargetCursor / GooeyNav / ElectricBorder などの前景演出が崩れない
  - [ ] PC / SP（iPhone SE 含む）で破綻なし

## アウトオブスコープ
- 各セクションの背景透過リブランディング（MySkills / Contact / WorkItem disabled）
- WebGL シェーダーのロジック変更
- `IntersectionObserver` 等の off-screen 停止最適化
- `prefers-reduced-motion` 対応の本格化