### PR TITLE
feat: 慣性スクロール (Lenis) + パララックス (GSAP ScrollTrigger) を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "framer-motion": "^12.19.1",
     "gsap": "^3.15.0",
+    "lenis": "^1.3.23",
     "ogl": "^1.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Footer from "./components/Footer";
 import Contact from "./components/Contact";
 import TargetCursor from "./components/TargetCursor";
 import SiteBackground from "./components/SiteBackground";
+import SmoothScrollProvider from "./components/SmoothScrollProvider";
 
 // グローバルスタイルを作成
 const GlobalStyle = createGlobalStyle`
@@ -43,7 +44,7 @@ const GlobalStyle = createGlobalStyle`
 
 const App: React.FC = () => {
   return (
-  <>
+  <SmoothScrollProvider>
     <GlobalStyle />
     <SiteBackground />
     <TargetCursor targetSelector=".cursor-target" />
@@ -54,7 +55,7 @@ const App: React.FC = () => {
       <Contact />
       <Footer />
     </div>
-  </>
+  </SmoothScrollProvider>
   );
 };
 

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import { useParallax } from "../../hooks/useParallax";
 import "./Profile.css";
 
 type Locale = "ja" | "en";
@@ -47,10 +48,12 @@ const content: Record<Locale, ProfileContent> = {
 const Profile: React.FC = () => {
   const [locale, setLocale] = useState<Locale>("ja");
   const current = content[locale];
+  const nameRef = useRef<HTMLDivElement>(null);
+  useParallax(nameRef, { yPercent: -25 });
 
   return (
     <div className="profile">
-      <div className="icon-wrapper">
+      <div className="icon-wrapper" ref={nameRef}>
         <h3 className="name">
           <p className="name-main">N-i-ke</p>
           <p className="name-sub">N-i-ke</p>

--- a/src/components/SmoothScrollProvider/SmoothScrollProvider.tsx
+++ b/src/components/SmoothScrollProvider/SmoothScrollProvider.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from 'react';
+import Lenis from 'lenis';
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+interface SmoothScrollProviderProps {
+  children: React.ReactNode;
+}
+
+const SmoothScrollProvider: React.FC<SmoothScrollProviderProps> = ({ children }) => {
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const lenis = new Lenis({
+      duration: 1.2,
+      easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+      smoothWheel: !prefersReducedMotion,
+      wheelMultiplier: 1,
+      touchMultiplier: 1.5,
+    });
+
+    lenis.on('scroll', ScrollTrigger.update);
+
+    const raf = (time: number) => {
+      lenis.raf(time * 1000);
+    };
+    gsap.ticker.add(raf);
+    gsap.ticker.lagSmoothing(0);
+
+    const onAnchorClick = (e: MouseEvent) => {
+      const composed = e.target as Element | null;
+      if (!composed) return;
+      const link = composed.closest('a[href^="#"]') as HTMLAnchorElement | null;
+      if (!link) return;
+      const href = link.getAttribute('href');
+      if (!href || href === '#') return;
+      const id = href.slice(1);
+      const target = document.getElementById(id);
+      if (!target) return;
+      e.preventDefault();
+      lenis.scrollTo(target, { duration: 1.2 });
+    };
+    document.addEventListener('click', onAnchorClick);
+
+    return () => {
+      document.removeEventListener('click', onAnchorClick);
+      gsap.ticker.remove(raf);
+      lenis.destroy();
+    };
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default SmoothScrollProvider;

--- a/src/components/SmoothScrollProvider/index.ts
+++ b/src/components/SmoothScrollProvider/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SmoothScrollProvider";

--- a/src/components/TopFv/TopFv.tsx
+++ b/src/components/TopFv/TopFv.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import GlitchText from '../GlitchText';
 import DecryptedLoader from '../DecryptedLoader';
 import ViewportHandler from '../ViewportHandler';
 import { useViewport } from '../../hooks/useViewport';
+import { useParallax } from '../../hooks/useParallax';
 
 import './Aurora.css';
 
@@ -10,6 +11,9 @@ const TopFv: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [contentVisible, setContentVisible] = useState(false);
   const { width: viewportWidth, isMobile } = useViewport();
+  const titleRef = useRef<HTMLDivElement>(null);
+
+  useParallax(titleRef, { yPercent: 60 });
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -45,7 +49,7 @@ const TopFv: React.FC = () => {
       <ViewportHandler />
       <DecryptedLoader isLoading={isLoading} onLoadingComplete={handleLoadingComplete} />
       <div className={`topfv-container ${contentVisible ? 'fade-in' : 'hidden'}`}>
-        <div className="portfolio-title">
+        <div className="portfolio-title" ref={titleRef}>
           <GlitchText
             speed={getGlitchSpeed()}
             enableShadows={true}

--- a/src/hooks/useParallax.ts
+++ b/src/hooks/useParallax.ts
@@ -1,0 +1,47 @@
+import { RefObject, useEffect } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+gsap.registerPlugin(ScrollTrigger);
+
+interface UseParallaxOptions {
+  /**
+   * 親要素のスクロール進行に対する移動量（%）。
+   * 正の値: 下方向にずらす（背景的・遅く見える）
+   * 負の値: 上方向にずらす（前景的・速く見える）
+   */
+  yPercent?: number;
+}
+
+export const useParallax = <T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  { yPercent = 20 }: UseParallaxOptions = {}
+) => {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    const tween = gsap.to(el, {
+      yPercent,
+      ease: "none",
+      scrollTrigger: {
+        trigger: el,
+        start: "top bottom",
+        end: "bottom top",
+        scrub: true,
+      },
+    });
+
+    return () => {
+      tween.scrollTrigger?.kill();
+      tween.kill();
+    };
+  }, [ref, yPercent]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,6 +661,11 @@ json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+lenis@^1.3.23:
+  version "1.3.23"
+  resolved "https://registry.npmjs.org/lenis/-/lenis-1.3.23.tgz#3473a956c829335682a6384df019d9a66457881c"
+  integrity sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==
+
 loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"


### PR DESCRIPTION
Closes #58

## 概要
drenty.jp 風の慣性スクロール + パララックスを実装。Lenis でスクロール全体を慣性化し、GSAP ScrollTrigger で主要要素にパララックスを付与。

## 変更内容

### 依存
- `lenis@^1.3` を追加（public npm registry を明示してコーポレートミラー混入を回避）

### `src/components/SmoothScrollProvider/`（新規）
- mount 時に `new Lenis({ duration: 1.2, easing: ... })` を 1 度だけ初期化
- `gsap.ticker.add` で Lenis の RAF を駆動
- `lenis.on('scroll', ScrollTrigger.update)` で GSAP の ScrollTrigger と同期
- アンカーリンク（`<a href="#section">`）を `document` で delegate 捕捉し、`lenis.scrollTo(target)` で慣性スクロールに置換
- `prefers-reduced-motion: reduce` 環境では `smoothWheel: false` で慣性を無効化

### `src/hooks/useParallax.ts`（新規）
- `ref` に対して `ScrollTrigger` + `scrub: true` で `yPercent` を変える再利用フック
- `prefers-reduced-motion` 環境では何もしない

### `App.tsx`
- 最上位を `<SmoothScrollProvider>` でラップ

### パララックス適用
| 要素 | yPercent | 効果 |
|---|---|---|
| `TopFv` の `.portfolio-title` | +60 | スクロールに対して下方向にゆっくり追従し、Aurora との奥行きが出る |
| `Profile` の `.icon-wrapper` (名前表示) | -25 | About セクション通過時に名前が上方向に少し浮かぶ |

WorkItem 画像のパララックスは figure / figcaption / ElectricBorder の重なりとレイアウト干渉する懸念があり、本 PR では一旦見送り（必要なら別 PR で対応）。

## 互換性確認
- `SiteBackground` / `TargetCursor` / `DecryptedLoader` は `position: fixed` のため慣性スクロールの影響を受けない
- `ElectricBorder` の canvas は ResizeObserver で再計測されるため、慣性が始まっても破綻しない
- Header の `<a href="#work">` 等は SmoothScrollProvider の delegate で `lenis.scrollTo` に置換、慣性アニメーションで目的セクションに移動

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功（バンドルサイズ: 477KB → 545KB minified / 167KB → 189KB gzip。lenis + ScrollTrigger 追加分）
- [x] `yarn dev` → 起動エラーなし
- [ ] ブラウザ目視:
  - [ ] ホイール / トラックパッド / タッチ操作で慣性が効く
  - [ ] Header メニュー（`#work`等）クリックで慣性付きで該当セクションに飛ぶ
  - [ ] TopFv タイトルがスクロールで遅れて追従する
  - [ ] About の名前表示が逆方向にゆっくり浮き沈みする
  - [ ] OS の「視差を減らす」設定で慣性 / パララックスが止まる

## アウトオブスコープ
- 全要素にパララックスを付与する大規模リブランディング
- WorkItem 画像のパララックス（別 PR でレイアウト調整込みで対応推奨）
- ScrollSmoother（GSAP Club 有料）の導入
- 横スクロール / セクション pin 等の重め演出