### PR TITLE
feat: ヘッダーをリデザイン + JA/EN 切替をヘッダーに統合

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Contact from "./components/Contact";
 import TargetCursor from "./components/TargetCursor";
 import SiteBackground from "./components/SiteBackground";
 import SmoothScrollProvider from "./components/SmoothScrollProvider";
+import { LocaleProvider } from "./contexts/LocaleContext";
 
 // グローバルスタイルを作成
 const GlobalStyle = createGlobalStyle`
@@ -44,18 +45,20 @@ const GlobalStyle = createGlobalStyle`
 
 const App: React.FC = () => {
   return (
-  <SmoothScrollProvider>
-    <GlobalStyle />
-    <SiteBackground />
-    <TargetCursor targetSelector=".cursor-target" />
-    <div className="App">
-      <Header />
-      <TopFv />
-      <HomePage />
-      <Contact />
-      <Footer />
-    </div>
-  </SmoothScrollProvider>
+  <LocaleProvider>
+    <SmoothScrollProvider>
+      <GlobalStyle />
+      <SiteBackground />
+      <TargetCursor targetSelector=".cursor-target" />
+      <div className="App">
+        <Header />
+        <TopFv />
+        <HomePage />
+        <Contact />
+        <Footer />
+      </div>
+    </SmoothScrollProvider>
+  </LocaleProvider>
   );
 };
 

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import SectionTitle from "../SectionTitle";
 import styled from "styled-components";
+import { useLocale, type Locale } from "../../contexts/LocaleContext";
 
-// Styled components
 const ContactSection = styled.section`
   padding-top: 20px;
   background-color: #808080;
@@ -52,34 +52,6 @@ const ContactWrapper = styled.div`
     transition: all 0.5s;
   }
 
-  .form-features {
-    margin-top: 30px;
-    color: #fff;
-    font-family: "Quicksand", sans-serif;
-    font-size: 0.9rem;
-    opacity: 0.8;
-  }
-
-  .form-features ul {
-    list-style: none;
-    padding: 0;
-    margin: 10px 0;
-  }
-
-  .form-features li {
-    margin: 5px 0;
-    padding-left: 20px;
-    position: relative;
-  }
-
-  .form-features li:before {
-    content: "✓";
-    position: absolute;
-    left: 0;
-    color: #4CAF50;
-    font-weight: bold;
-  }
-
   @media screen and (max-width: 1000px) {
     .sub-sec-title {
       left: 40%;
@@ -116,25 +88,54 @@ const ContactWrapper = styled.div`
   }
 `;
 
+type ContactCopy = {
+  subTitle: string;
+  description: React.ReactNode;
+  buttonLabel: string;
+};
+
+const copy: Record<Locale, ContactCopy> = {
+  ja: {
+    subTitle: "お問い合わせ",
+    description: (
+      <>
+        お問い合わせは以下ボタンからGoogleフォームにアクセスしてください。
+        <br />
+        お気軽にご連絡ください。
+      </>
+    ),
+    buttonLabel: "お問い合わせフォームを開く",
+  },
+  en: {
+    subTitle: "Contact",
+    description: (
+      <>
+        Please use the Google Form below to get in touch.
+        <br />
+        Feel free to reach out about anything.
+      </>
+    ),
+    buttonLabel: "Open contact form",
+  },
+};
+
 const Contact: React.FC = () => {
+  const { locale } = useLocale();
+  const c = copy[locale];
+
   return (
     <ContactSection id="contact">
-      <SectionTitle mainTitle="Contact" subTitle="Contact" />
-      <ContactWrapper className="contact-wrapper">
+      <SectionTitle mainTitle="Contact" subTitle={c.subTitle} />
+      <ContactWrapper className="contact-wrapper" lang={locale}>
         <div className="contact-info">
-          <p className="contact-text">
-            お問い合わせは以下ボタンからGoogleフォームにアクセスしてください。
-            <br />
-            お気軽にご連絡ください。
-          </p>
-          
-          <a 
-            href="https://docs.google.com/forms/d/14xlSmgOBjRniA-eGkcnvbUB025-Yzt0Q8f4iQlZ2DnE/viewform" 
-            target="_blank" 
+          <p className="contact-text">{c.description}</p>
+          <a
+            href="https://docs.google.com/forms/d/14xlSmgOBjRniA-eGkcnvbUB025-Yzt0Q8f4iQlZ2DnE/viewform"
+            target="_blank"
             rel="noopener noreferrer"
-            className="google-form-button"
+            className="google-form-button cursor-target"
           >
-            お問い合わせフォームを開く
+            {c.buttonLabel}
           </a>
         </div>
       </ContactWrapper>

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,14 +1,16 @@
 /* Header.css */
+/* styled-components が後勝ちで上書きする可能性があるため、全て !important で固定 */
 
-/* PC のみ表示 */
 .header-bar--desktop {
   display: flex !important;
 }
 
-/* SP のみ表示 */
-.header-bar--mobile,
+.header-bar--mobile {
+  display: none !important;
+}
+
 .header-drawer {
-  display: none;
+  display: none !important;
 }
 
 @media screen and (max-width: 768px) {
@@ -19,6 +21,6 @@
     display: flex !important;
   }
   .header-drawer {
-    display: block;
+    display: block !important;
   }
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,55 +1,24 @@
 /* Header.css */
-.mobile-menu {
+
+/* PC のみ表示 */
+.header-bar--desktop {
+  display: flex !important;
+}
+
+/* SP のみ表示 */
+.header-bar--mobile,
+.header-drawer {
   display: none;
 }
 
-.desktop-menu {
-  display: flex;
-}
-
-/* リンク色の統一 */
-.mobile-menu a {
-  color: white !important;
-  text-decoration: none;
-}
-
-.mobile-menu a:hover {
-  color: white !important;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
-}
-
-/* Mobile styles */
 @media screen and (max-width: 768px) {
-  .mobile-menu {
+  .header-bar--desktop {
+    display: none !important;
+  }
+  .header-bar--mobile {
+    display: flex !important;
+  }
+  .header-drawer {
     display: block;
   }
-  
-  .desktop-menu {
-    display: none !important;
-    visibility: hidden;
-    opacity: 0;
-    height: 0;
-    overflow: hidden;
-    position: absolute;
-    pointer-events: none;
-  }
 }
-
-/* Desktop styles */
-@media screen and (min-width: 769px) {
-  .mobile-menu {
-    display: none !important;
-    visibility: hidden;
-    opacity: 0;
-    height: 0;
-    overflow: hidden;
-    position: absolute;
-    pointer-events: none;
-  }
-  
-  .desktop-menu {
-    display: flex !important;
-    visibility: visible;
-    opacity: 1;
-  }
-} 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -160,6 +160,53 @@ const DrawerLangSection = styled.div`
   gap: 10px;
 `;
 
+const DrawerCloseButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  cursor: pointer;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    width: 18px;
+    height: 2px;
+    background-color: #fff;
+    border-radius: 1px;
+  }
+
+  &::before {
+    transform: rotate(45deg);
+  }
+
+  &::after {
+    transform: rotate(-45deg);
+  }
+
+  &:hover {
+    background-color: rgba(0, 216, 255, 0.15);
+    border-color: rgba(0, 216, 255, 0.55);
+    transform: rotate(90deg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #00d8ff;
+    outline-offset: 2px;
+  }
+`;
+
 const DrawerLangLabel = styled.span`
   font-family: "Courier New", "Menlo", monospace;
   font-size: 0.7rem;
@@ -321,6 +368,12 @@ const Header: React.FC = () => {
       {/* Mobile drawer */}
       <div className="header-drawer">
         <Nav isOpen={isOpen} aria-hidden={!isOpen}>
+          <DrawerCloseButton
+            type="button"
+            className="cursor-target"
+            onClick={closeMenu}
+            aria-label="Close menu"
+          />
           <ul className="nav-menu">
             {items.map((item) => (
               <li key={item.href}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,10 +1,102 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import GooeyNav from '../GooeyNav';
-import './Header.css';
+import GooeyNav from "../GooeyNav";
+import { useLocale, type Locale } from "../../contexts/LocaleContext";
+import "./Header.css";
 
 const HeaderContainer = styled.header`
   text-align: center;
+  font-family: "Quicksand", sans-serif;
+`;
+
+const Bar = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 60px;
+  z-index: 99;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 clamp(16px, 3vw, 32px);
+  background-color: rgba(14, 8, 8, 0.55);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-sizing: border-box;
+  border-bottom: 1px solid rgba(0, 216, 255, 0.18);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35), 0 1px 12px rgba(0, 216, 255, 0.12);
+  color: #fff;
+`;
+
+const Brand = styled.a`
+  font-family: "Courier New", "Menlo", monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  color: #ffffff !important;
+  text-decoration: none;
+  text-transform: uppercase;
+  text-shadow: 0 0 12px rgba(0, 216, 255, 0.35);
+  white-space: nowrap;
+  transition: text-shadow 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    text-shadow: 0 0 16px rgba(0, 216, 255, 0.6);
+    transform: translateY(-1px);
+  }
+`;
+
+const NavCenter = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+`;
+
+const RightCluster = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+`;
+
+const LangToggleWrapper = styled.div`
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(0, 216, 255, 0.45);
+  border-radius: 999px;
+  padding: 3px;
+  background-color: rgba(0, 0, 0, 0.25);
+`;
+
+const LangButton = styled.button<{ $active: boolean }>`
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  font-family: "Courier New", "Menlo", monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  padding: 6px 12px;
+  min-width: 44px;
+  min-height: 30px;
+  border-radius: 999px;
+  background-color: ${({ $active }) => ($active ? "#00d8ff" : "transparent")};
+  color: ${({ $active }) => ($active ? "#0b0b0b" : "#cfeaff")};
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: ${({ $active }) => ($active ? "0 0 10px rgba(0, 216, 255, 0.55)" : "none")};
+
+  &:hover {
+    color: ${({ $active }) => ($active ? "#0b0b0b" : "#ffffff")};
+    background-color: ${({ $active }) =>
+      $active ? "#00d8ff" : "rgba(0, 216, 255, 0.12)"};
+  }
+
+  &:focus-visible {
+    outline: 2px solid #00d8ff;
+    outline-offset: 2px;
+  }
 `;
 
 const Nav = styled.nav<{ isOpen: boolean }>`
@@ -16,55 +108,84 @@ const Nav = styled.nav<{ isOpen: boolean }>`
   top: 0;
   left: ${(props) => (props.isOpen ? "0" : "-400px")};
   opacity: ${(props) => (props.isOpen ? "1" : "0")};
-  transition: all 0.15s;
+  background-color: rgba(14, 8, 8, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: all 0.2s ease;
   overflow-x: hidden;
   overflow-y: auto;
   font-family: "Quicksand", sans-serif;
+  display: flex;
+  flex-direction: column;
 
   ul {
-    padding: 70px 0;
+    padding: 80px 0 24px;
+    margin: 0;
   }
 
   li {
-    padding: 0 0;
-    border-bottom: 1px solid #fff;
+    padding: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
 
     &:first-child {
-      border-top: 1px solid #fff;
+      border-top: 1px solid rgba(255, 255, 255, 0.18);
     }
   }
 
   a {
-    padding: 10px;
+    padding: 16px;
+    min-height: 44px;
     color: #fff !important;
     text-align: center;
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: all 0.15s;
+    letter-spacing: 0.12em;
 
     &:hover {
       color: #fff !important;
-      background-color: rgba(255, 255, 255, 0.2);
-      font-size: 1.3rem;
-      text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
+      background-color: rgba(0, 216, 255, 0.15);
+      text-shadow: 0 0 8px rgba(0, 216, 255, 0.8);
     }
   }
 `;
 
-const MenuButton = styled.div`
-  display: block;
-  position: fixed;
-  top: 25px;
-  right: 25px;
-  z-index: 999;
-  width: 40px;
-  height: 40px;
+const DrawerLangSection = styled.div`
+  margin-top: auto;
+  padding: 24px 16px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;
+
+const DrawerLangLabel = styled.span`
+  font-family: "Courier New", "Menlo", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  color: rgba(207, 234, 255, 0.7);
+  text-transform: uppercase;
+`;
+
+const MenuButton = styled.button`
+  appearance: none;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 44px;
+  height: 44px;
   border-radius: 10px;
   cursor: pointer;
   transition: all 0.15s;
+  padding: 0;
 
   span {
     position: absolute;
-    left: 5px;
+    left: 7px;
     display: block;
     width: 30px;
     height: 2px;
@@ -73,20 +194,20 @@ const MenuButton = styled.div`
     transition: all 0.15s;
 
     &:nth-child(1) {
-      top: 9px;
+      top: 14px;
     }
 
     &:nth-child(2) {
-      top: 19px;
+      top: 22px;
     }
 
     &:nth-child(3) {
-      top: 29px;
+      top: 30px;
     }
   }
 
   &.open span:nth-child(1) {
-    transform: translateY(10px) rotate(-315deg);
+    transform: translateY(8px) rotate(-315deg);
   }
 
   &.open span:nth-child(2) {
@@ -94,7 +215,12 @@ const MenuButton = styled.div`
   }
 
   &.open span:nth-child(3) {
-    transform: translateY(-10px) rotate(315deg);
+    transform: translateY(-8px) rotate(315deg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #00d8ff;
+    outline-offset: 2px;
   }
 `;
 
@@ -111,33 +237,42 @@ const Mask = styled.div<{ isOpen: boolean }>`
   transition: all 0.15s;
 `;
 
-const GooeyNavWrapper = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 60px;
-  z-index: 99;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: #fff;
-  background-color: rgba(14, 8, 8, 0.8);
-  backdrop-filter: blur(5px);
-`;
+interface LangToggleProps {
+  locale: Locale;
+  onChange: (next: Locale) => void;
+  className?: string;
+}
+
+const LangToggle: React.FC<LangToggleProps> = ({ locale, onChange, className }) => (
+  <LangToggleWrapper className={className} role="group" aria-label="Language">
+    <LangButton
+      type="button"
+      className="cursor-target"
+      $active={locale === "ja"}
+      aria-pressed={locale === "ja"}
+      onClick={() => onChange("ja")}
+    >
+      JA
+    </LangButton>
+    <LangButton
+      type="button"
+      className="cursor-target"
+      $active={locale === "en"}
+      aria-pressed={locale === "en"}
+      onClick={() => onChange("en")}
+    >
+      EN
+    </LangButton>
+  </LangToggleWrapper>
+);
 
 const Header: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { locale, setLocale } = useLocale();
 
-  const toggleMenu = () => {
-    setIsOpen(!isOpen);
-  };
+  const toggleMenu = () => setIsOpen((prev) => !prev);
+  const closeMenu = () => setIsOpen(false);
 
-  const closeMenu = () => {
-    setIsOpen(false);
-  };
-
-  // Nav items for GooeyNav
   const items = [
     { label: "TOP", href: "#top" },
     { label: "WORK", href: "#work" },
@@ -149,40 +284,59 @@ const Header: React.FC = () => {
 
   return (
     <HeaderContainer id="top" className={isOpen ? "open" : ""}>
-      {/* Mobile menu (hidden on desktop) */}
-      <div className="mobile-menu">
-        <Nav isOpen={isOpen}>
+      {/* Desktop top bar */}
+      <Bar className="header-bar header-bar--desktop">
+        <Brand href="#top" className="cursor-target" aria-label="Back to top">
+          N-I-KE
+        </Brand>
+        <NavCenter>
+          <GooeyNav items={items} particleCount={4} animationTime={100} timeVariance={50} />
+        </NavCenter>
+        <RightCluster>
+          <LangToggle locale={locale} onChange={setLocale} />
+        </RightCluster>
+      </Bar>
+
+      {/* Mobile top bar */}
+      <Bar className="header-bar header-bar--mobile">
+        <Brand href="#top" className="cursor-target" aria-label="Back to top">
+          N-I-KE
+        </Brand>
+        <RightCluster>
+          <LangToggle locale={locale} onChange={setLocale} />
+          <MenuButton
+            type="button"
+            className={isOpen ? "open" : ""}
+            onClick={toggleMenu}
+            aria-label={isOpen ? "Close menu" : "Open menu"}
+            aria-expanded={isOpen}
+          >
+            <span />
+            <span />
+            <span />
+          </MenuButton>
+        </RightCluster>
+      </Bar>
+
+      {/* Mobile drawer */}
+      <div className="header-drawer">
+        <Nav isOpen={isOpen} aria-hidden={!isOpen}>
           <ul className="nav-menu">
             {items.map((item) => (
               <li key={item.href}>
-                <a
-                  href={item.href}
-                  className={item.href.slice(1)}
-                  onClick={closeMenu}
-                >
+                <a href={item.href} className={item.href.slice(1)} onClick={closeMenu}>
                   {item.label}
                 </a>
               </li>
             ))}
           </ul>
+          <DrawerLangSection>
+            <DrawerLangLabel>Language</DrawerLangLabel>
+            <LangToggle locale={locale} onChange={setLocale} />
+          </DrawerLangSection>
         </Nav>
-        <MenuButton className={isOpen ? "open" : ""} onClick={toggleMenu}>
-          <span></span>
-          <span></span>
-          <span></span>
-        </MenuButton>
-        <Mask isOpen={isOpen} onClick={closeMenu}></Mask>
+        <Mask isOpen={isOpen} onClick={closeMenu} />
       </div>
-
-      {/* Desktop GooeyNav menu */}
-      <GooeyNavWrapper className="desktop-menu">
-        <GooeyNav
-          items={items}
-          particleCount={4}
-          animationTime={100}
-          timeVariance={50}
-        />
-      </GooeyNavWrapper>
     </HeaderContainer>
   );
 };

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -4,13 +4,32 @@ import Profile from "../Profile";
 import MySkills from "../MySkills";
 import Service from "../Service";
 import { works } from "../../data/works";
+import { useLocale, type Locale } from "../../contexts/LocaleContext";
+
+const subtitles: Record<Locale, Record<"work" | "about" | "skill" | "service", string>> = {
+  ja: {
+    work: "実績一覧",
+    about: "私について",
+    skill: "保有スキル",
+    service: "提供できること",
+  },
+  en: {
+    work: "My Works",
+    about: "About",
+    skill: "My Skills",
+    service: "My Service",
+  },
+};
 
 const HomePage = () => {
+  const { locale } = useLocale();
+  const t = subtitles[locale];
+
   return (
     <main id="main">
       {/* work */}
       <section id="work">
-        <SectionTitle mainTitle="Works" subTitle="My Works" />
+        <SectionTitle mainTitle="Works" subTitle={t.work} />
         <div className="work-wrapper">
           <ul>
             {works.map((work) => (
@@ -21,18 +40,18 @@ const HomePage = () => {
       </section>
       {/* about */}
       <section id="about">
-        <SectionTitle mainTitle="About" subTitle="About" />
+        <SectionTitle mainTitle="About" subTitle={t.about} />
         <Profile />
       </section>
       {/* image-sec */}
       <div className="image-sec"></div>
       <section id="skill">
-        <SectionTitle mainTitle="Skills" subTitle="My Skills" />
+        <SectionTitle mainTitle="Skills" subTitle={t.skill} />
         <MySkills />
       </section>
       {/* service */}
       <section id="service">
-        <SectionTitle mainTitle="Service" subTitle="My Service" />
+        <SectionTitle mainTitle="Service" subTitle={t.service} />
         <Service />
       </section>
     </main>

--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -2,45 +2,6 @@
   padding-bottom: 70px;
 }
 
-.profile-lang-tabs {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  margin: 16px 0 28px;
-}
-
-.profile-lang-tab {
-  appearance: none;
-  background: transparent;
-  border: 1px solid rgba(255, 46, 99, 0.6);
-  color: #ff2e63;
-  padding: 8px 20px;
-  min-width: 64px;
-  min-height: 36px;
-  font-family: "Quicksand", sans-serif;
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 2px;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.profile-lang-tab:hover {
-  background-color: rgba(255, 46, 99, 0.08);
-}
-
-.profile-lang-tab.is-active {
-  background-color: #ff2e63;
-  color: #fff;
-  box-shadow: 0 0 8px rgba(255, 46, 99, 0.45);
-}
-
-.profile-lang-tab:focus-visible {
-  outline: 2px solid #ff2e63;
-  outline-offset: 2px;
-}
-
 #about .icon-wrapper {
   width: 80%;
   margin-right: 10%;

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,9 +1,8 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import { useParallax } from "../../hooks/useParallax";
 import EarthBackground from "../EarthBackground";
+import { useLocale, type Locale } from "../../contexts/LocaleContext";
 import "./Profile.css";
-
-type Locale = "ja" | "en";
 
 type ProfileContent = {
   historyHeading: string;
@@ -47,7 +46,7 @@ const content: Record<Locale, ProfileContent> = {
 };
 
 const Profile: React.FC = () => {
-  const [locale, setLocale] = useState<Locale>("ja");
+  const { locale } = useLocale();
   const current = content[locale];
   const nameRef = useRef<HTMLDivElement>(null);
   useParallax(nameRef, { yPercent: -25 });
@@ -59,27 +58,6 @@ const Profile: React.FC = () => {
           <p className="name-main">N-i-ke</p>
           <p className="name-sub">N-i-ke</p>
         </h3>
-      </div>
-
-      <div className="profile-lang-tabs" role="tablist" aria-label="Language">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={locale === "ja"}
-          className={`profile-lang-tab cursor-target ${locale === "ja" ? "is-active" : ""}`}
-          onClick={() => setLocale("ja")}
-        >
-          JA
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={locale === "en"}
-          className={`profile-lang-tab cursor-target ${locale === "en" ? "is-active" : ""}`}
-          onClick={() => setLocale("en")}
-        >
-          EN
-        </button>
       </div>
 
       <div className="about-wrapper" lang={locale}>

--- a/src/components/Service/Service.tsx
+++ b/src/components/Service/Service.tsx
@@ -1,22 +1,55 @@
 import React from "react";
+import { useLocale, type Locale } from "../../contexts/LocaleContext";
 import "./Service.css";
 
+type ServiceCard = {
+  heading: string;
+  body: string;
+};
+
+type ServiceCopy = {
+  left: ServiceCard;
+  right: ServiceCard;
+};
+
+const copy: Record<Locale, ServiceCopy> = {
+  ja: {
+    left: {
+      heading: "Webアプリケーション開発",
+      body: "現職がWebアプリケーション開発のフロントエンドエンジニアという経歴から、React.js・Next.js・TypeScriptを使ったWebアプリケーション開発を得意としています。",
+    },
+    right: {
+      heading: "LP・ECサイト制作 (WordPress/Shopify)",
+      body: "スマートフォンサイト、WordPress を使った更新性の高いサイト、Shopify を使った EC サイトなど、静的なサイトから動的なサイトまで様々なサイトのコーディングを行っております。",
+    },
+  },
+  en: {
+    left: {
+      heading: "Web Application Development",
+      body: "Working as a front-end engineer in web application development, I specialize in building modern web apps with React.js, Next.js, and TypeScript.",
+    },
+    right: {
+      heading: "Landing Pages & EC Sites (WordPress / Shopify)",
+      body: "I handle a wide range of coding work — from responsive mobile sites and content-rich WordPress builds to Shopify-based EC sites — covering both static and dynamic implementations.",
+    },
+  },
+};
+
 const Service: React.FC = () => {
+  const { locale } = useLocale();
+  const c = copy[locale];
+
   return (
-    <div className="service-wrapper">
+    <div className="service-wrapper" lang={locale}>
       <div className="service-wrap-left wrapper">
         <i className="fas fa-edit"></i>
-        <h3>Webアプリケーション開発</h3>
-        <p>
-          現職がWebアプリケーション開発のフロントエンドエンジニアという経歴から、React.js•Next.js•TypeScriptを使ったWebアプリケーション開発を得意としています。
-        </p>
+        <h3>{c.left.heading}</h3>
+        <p>{c.left.body}</p>
       </div>
       <div className="service-wrap-right wrapper">
         <i className="fas fa-laptop-code"></i>
-        <h3>LP•ECサイト制作 (WordPress/Shopify)</h3>
-        <p>
-          スマートフォンサイト、ワードプレスを使用した更新性の高いサイト、Shopifyを使用したECサイトなど、静的なサイトから動的なサイトまで様々なサイトのコーディングを行っております。
-        </p>
+        <h3>{c.right.heading}</h3>
+        <p>{c.right.body}</p>
       </div>
     </div>
   );

--- a/src/contexts/LocaleContext.tsx
+++ b/src/contexts/LocaleContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+export type Locale = "ja" | "en";
+
+interface LocaleContextValue {
+  locale: Locale;
+  setLocale: (next: Locale) => void;
+}
+
+const STORAGE_KEY = "locale";
+
+const isLocale = (value: unknown): value is Locale => value === "ja" || value === "en";
+
+const readStoredLocale = (): Locale => {
+  if (typeof window === "undefined") return "ja";
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (isLocale(stored)) return stored;
+  } catch {
+    // localStorage が使えない環境 (private mode 等) はデフォルトにフォールバック
+  }
+  return "ja";
+};
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+interface LocaleProviderProps {
+  children: React.ReactNode;
+}
+
+export const LocaleProvider: React.FC<LocaleProviderProps> = ({ children }) => {
+  const [locale, setLocaleState] = useState<Locale>(readStoredLocale);
+
+  const setLocale = useCallback((next: Locale) => {
+    setLocaleState(next);
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, locale);
+    } catch {
+      // 永続化失敗は致命ではないので無視
+    }
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  return (
+    <LocaleContext.Provider value={{ locale, setLocale }}>{children}</LocaleContext.Provider>
+  );
+};
+
+export const useLocale = (): LocaleContextValue => {
+  const ctx = useContext(LocaleContext);
+  if (!ctx) {
+    throw new Error("useLocale must be used within a LocaleProvider");
+  }
+  return ctx;
+};


### PR DESCRIPTION
Closes #62

## 概要
ヘッダーをサイト全体のサイバー系トーンに合わせてリデザイン。同時に、Profile セクション内に閉じていた JA/EN 切替をヘッダーに昇格させ、サイト全体で共有する `LocaleContext` を新設。

## 変更内容

### 言語状態のグローバル化
- `src/contexts/LocaleContext.tsx` を新規作成
  - `type Locale = 'ja' | 'en'`、`LocaleProvider`、`useLocale()` を提供
  - 初期値は `localStorage` から復元（キー: `locale`、無ければ `'ja'`）
  - 変更時に `localStorage` へ書き戻し、`<html lang>` も同期
- `App.tsx` で `<LocaleProvider>` で `SmoothScrollProvider` の外側を wrap
- `Profile.tsx` の自前 `useState<Locale>` と言語タブ UI を撤去し、`useLocale()` から消費

### ヘッダーのリデザイン
- 3 ペイン構成（PC / SP 共通）:
  - 左: ブランド表記 `N-I-KE`（monospace + letter-spacing + cyan glow）
  - 中央: 既存の GooeyNav（PC のみ）
  - 右: `LangToggle`（pill 形状の 2 ボタン）+ ハンバーガー（SP のみ）
- スタイル:
  - 背景: `rgba(14, 8, 8, 0.55)` + `backdrop-filter: blur(12px)`
  - 下辺グロー: `border-bottom: 1px solid rgba(0,216,255,0.18)` + `box-shadow` で cyan の柔らかい光
- `LangToggle`:
  - アクティブ: `#00d8ff` 背景 + 内側影
  - 非アクティブ: 透明 + hover でうっすら cyan
  - 各ボタンに `cursor-target` クラスを付与し、TargetCursor のロックオン対象に
  - `aria-pressed` で選択状態、`focus-visible` で可視フォーカス
  - 最小タップ領域 44×30（pill 形状で押しやすく）
- SP の挙動:
  - 上部固定 mobile bar に「ブランド + LangToggle + ハンバーガー」が並ぶ
  - ドロワー底部にも `Language` ラベル付きの LangToggle を再掲（メニュー内でも切替可能）
- `MenuButton` を `<div onClick>` から `<button>` に変更し、`aria-label` / `aria-expanded` を付与（a11y 改善）
- `Header.css` の暗黙的な `.desktop-menu` / `.mobile-menu` 切替を `.header-bar--desktop` / `.header-bar--mobile` / `.header-drawer` に明示化

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功
- [ ] ブラウザ目視:
  - [ ] PC で「ブランド | Nav | LangToggle」3 ペイン構成が均等に並ぶ
  - [ ] SP でも mobile bar に LangToggle + ハンバーガーが見える
  - [ ] ヘッダーのいずれの LangToggle を押しても About の本文が即時切り替わる
  - [ ] リロード後も最後に選んだ言語が維持される（localStorage）
  - [ ] LangToggle ホバー時に TargetCursor のロックオン演出が出る
  - [ ] フォーカス可視 / キーボード操作で問題なし

## アウトオブスコープ
- Service / Contact / Footer 等の本文翻訳
- next-i18next 等の i18n フレームワーク
- スクロール量で Header が縮む / 隠れる挙動
- バンドルサイズ最適化