### PR TITLE
fix: SP の About と Service の文字サイズを Contact に揃える

### DIFF
--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -119,6 +119,6 @@
     margin-top: 30px;
   }
   #about .about-wrapper p {
-    font-size: 0.3rem;
+    font-size: 1rem;
   }
 }

--- a/src/components/Service/Service.css
+++ b/src/components/Service/Service.css
@@ -55,27 +55,35 @@
   font-size: 1rem;
 }
 
+@media screen and (max-width: 768px) {
+  #service .service-wrapper {
+    margin-right: 8%;
+    margin-left: 8%;
+    display: block;
+  }
+  #service .service-wrap-right,
+  #service .service-wrap-left {
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 28px;
+    padding: 24px 20px;
+  }
+  #service .service-wrap-right h3,
+  #service .service-wrap-left h3 {
+    font-size: 1.1rem;
+  }
+  #service .service-wrap-right p,
+  #service .service-wrap-left p {
+    font-size: 1rem;
+  }
+  #service i {
+    font-size: 2.4rem;
+  }
+}
+
 @media screen and (max-width: 600px) {
   #service {
     padding-bottom: 80px;
-  }
-  #service .service-wrapper {
-    margin-right: 15%;
-    margin-left: 15%;
-    display: block;
-    font-size: 0.7rem;
-  }
-  #service .service-wrap-right {
-    width: 100%;
-    margin-bottom: 0;
-    margin-right: 0;
-    padding: 20px;
-  }
-  #service .service-wrap-left {
-    width: 100%;
-    margin-bottom: 40px;
-    margin-right: 0;
-    padding: 20px;
   }
   #service .sub-sec-title {
     left: 35%;
@@ -83,28 +91,25 @@
 }
 
 @media screen and (max-width: 480px) {
-  #service {
-    padding-bottom: 80px;
-  }
   #service .service-wrapper {
-    margin-right: 15%;
-    margin-left: 15%;
-    display: block;
-    font-size: 0.7rem;
+    margin-right: 6%;
+    margin-left: 6%;
   }
-  #service .service-wrap-right {
-    width: 100%;
-    margin-bottom: 0;
-    margin-right: 0;
-    padding: 15px;
-  }
+  #service .service-wrap-right,
   #service .service-wrap-left {
-    width: 100%;
-    margin-bottom: 40px;
-    margin-right: 0;
-    padding: 15px;
+    padding: 18px 14px;
+    margin-bottom: 24px;
   }
-  #service .sub-sec-title {
-    left: 35%;
+  #service .service-wrap-right h3,
+  #service .service-wrap-left h3 {
+    font-size: 1.05rem;
+  }
+  #service .service-wrap-right p,
+  #service .service-wrap-left p {
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+  #service i {
+    font-size: 2.2rem;
   }
 }


### PR DESCRIPTION
## 問題
SP で表示したとき、

- **About**: 本文が極端に小さい（実質読めない）
- **Service**: 全体的に大きすぎる

の状態だった。Contact の SP 本文サイズ（1rem）に揃えてバランスを取る。

## 原因と修正

### About
`Profile.css` の `max-width: 480px` で `#about .about-wrapper p { font-size: 0.3rem }` が残っていた（≒ 4.8px、実質読めないサイズ）。
- → `font-size: 1rem` に修正（Contact の本文と同じサイズ）

### Service
- `.service-wrapper { font-size: 0.7rem }` は親要素にだけ設定されており、子の `h3` / `p` は `rem` で明示指定されているため実質効いていなかった。撤去
- `h3` / `p` / `i` の SP サイズを明示的にダウン
- 768px の中間段階を追加して 2 カラム → 縦並びの遷移を整理

| 要素 | 修正前 (PC / SP) | 修正後 (PC / 768px / 480px) |
|---|---|---|
| `h3` | 1.2rem / 1.2rem | 1.2rem / 1.1rem / 1.05rem |
| `p` | 1rem / 1rem | 1rem / 1rem / 1rem |
| `i` | 3rem / 3rem | 3rem / 2.4rem / 2.2rem |

これで Contact の SP 本文（1rem）と About / Service の本文が同じ font-size になる。

## 検証
- [x] `yarn build` → 成功
- [ ] iPhone SE (375) / iPhone (390) / iPad (768) で About と Service の本文が Contact と同じくらいの読みやすさになっていること