### PR TITLE
feat: Google Analytics 4 (GA4) を導入してアクセス計測を開始

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# 各環境ごとの .env / .env.local / .env.production 用テンプレート。
+# 個人別オーバーライドが必要な場合は .env.local にコピーして書き換える
+# (.env*.local は .gitignore で除外済み)。
+
+# Google Analytics 4 - Measurement ID
+# 本番ビルド時に index.html へ %VITE_GA_MEASUREMENT_ID% として埋め込まれる。
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,7 @@
+# 本番ビルド (yarn build) 時に参照される環境変数
+# Vite は %VITE_VARIABLE_NAME% の形で index.html 内に埋め込む
+
+# Google Analytics 4 - Measurement ID
+# GA4 仕様上、Measurement ID は公開識別子（本番ページの HTML を見れば誰でも取得可能）。
+# シークレットではないためコミットして問題ない。
+VITE_GA_MEASUREMENT_ID=G-8HD78GNJH4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ docs/
 
 # Logs
 *.log
+
+# Vite env (local overrides only — .env / .env.production はコミット対象)
+.env.local
+.env.*.local

--- a/index.html
+++ b/index.html
@@ -13,6 +13,18 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <title>N-i-ke</title>
+
+    <!-- Google tag (gtag.js)
+         Measurement ID は .env.production の VITE_GA_MEASUREMENT_ID から
+         Vite のビルド時 interpolation で埋め込まれる。
+         dev サーバーでは値が空になるため実質的な計測は発生しない。 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_MEASUREMENT_ID%"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '%VITE_GA_MEASUREMENT_ID%', { anonymize_ip: true });
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Closes #65

## 概要
本サイト（GitHub Pages デプロイ）に Google Analytics 4 (GA4) を導入し、訪問者数やセッションを計測できるようにする。Measurement ID は `G-8HD78GNJH4`（GA4 プロパティ作成済み）。

## オープンソースとの兼ね合い
- GA4 Measurement ID は仕様上「**公開識別子**」であり、本番ページの HTML を見れば誰でも取得可能。秘密値ではない
- リポジトリに含めても機能的にリスクはない
- スパム送信（第三者が同じ ID を別サイトに仕込む）への対策は GA4 Admin 側で `unwanted referrers` / `internal traffic` 設定で対応する想定（本 PR スコープ外）

## 変更内容

### 新規ファイル
- **`.env.production`** (コミット対象): `VITE_GA_MEASUREMENT_ID=G-8HD78GNJH4`
  - `yarn build` 実行時に Vite が読み込み、`%VITE_GA_MEASUREMENT_ID%` を実値に置換
- **`.env.example`** (コミット対象): プレースホルダ `G-XXXXXXXXXX` 付きのドキュメント

### `.gitignore`
- `.env.local` / `.env.*.local` を追加（個人別オーバーライド用、コミット対象外）

### `index.html`
- `<head>` 末尾に Google 公式の gtag.js スニペットを追加
- `id` 部分を `%VITE_GA_MEASUREMENT_ID%` で env interpolation
- `gtag('config', ..., { anonymize_ip: true })` で IP 匿名化を有効化
- dev サーバーでは env が空のため計測発火なし（開発トラフィックを GA に混ぜない）

## 検証
- [x] `yarn build` 成功
- [x] `docs/index.html` に `G-8HD78GNJH4` が 2 箇所（script src と gtag config）で正しく埋め込まれることを確認
- [ ] main マージ → GitHub Pages 自動デプロイ後、サイトアクセス時に GA4 のリアルタイムレポートで pingback されることを確認
- [ ] GA4 Admin で本番ドメイン `n-i-ke.github.io` 以外を `internal traffic` / `unwanted referrers` でフィルタ（管理画面で別途）

## アウトオブスコープ
- Cookie 同意バナー（個人ポートフォリオ用途のため省略。必要なら別 Issue）
- セクション別カスタムイベント（IntersectionObserver 経由の page_view 拡張）
- Google Tag Manager
- BigQuery エクスポート