### PR TITLE
feat: Header (desktop) と Footer にリポジトリ (GitHub) への導線を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ JA / EN の言語切替に対応し、サイト全体に演出系のアニメー
 | スタイリング | styled-components 6 / 通常 CSS / CSS Modules 風命名 |
 | アイコン | react-icons |
 | ホスティング | GitHub Pages (Actions 経由デプロイ) |
-| アクセス解析 | Google Analytics 4 (`G-8HD78GNJH4`, IP 匿名化済み) |
 
 ### アニメーション / 演出系ライブラリ
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,47 +1,76 @@
 import React from "react";
 import styled from "styled-components";
+import { FaGithub } from "react-icons/fa";
+
+const REPO_URL = "https://github.com/N-i-ke/self-introduction";
 
 const FooterContainer = styled.footer`
   text-align: center;
   background-color: rgba(28, 28, 28, 1);
   color: #fff;
-  height: 70px;
+  padding: 20px 16px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 12px;
+  font-family: "Quicksand", sans-serif;
 
-  .footer {
-    display: inline-block;
-    vertical-align: middle;
-    font-family: "Quicksand", sans-serif;
-  }
-
-  .btn-sns {
-    font-size: 5rem;
-    letter-spacing: 0;
-    color: #fff;
+  .footer-copy {
     margin: 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.7);
   }
 
-  p {
-    text-align: center;
+  .github-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #ffffff;
+    text-decoration: none;
+    border: 1px solid rgba(0, 216, 255, 0.45);
+    background-color: rgba(0, 0, 0, 0.25);
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-family: "Courier New", "Menlo", monospace;
+    font-size: 0.8rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    min-height: 36px;
   }
 
-  i {
-    transition: all 0.5s;
+  .github-link:hover {
+    color: #00d8ff;
+    border-color: rgba(0, 216, 255, 0.85);
+    background-color: rgba(0, 216, 255, 0.08);
+    box-shadow: 0 0 12px rgba(0, 216, 255, 0.35);
+  }
 
-    &:hover {
-      color: #1da1f2;
-      transform: rotate(25deg);
-      transition: all 0.5s;
-    }
+  .github-link:focus-visible {
+    outline: 2px solid #00d8ff;
+    outline-offset: 2px;
+  }
+
+  .github-link svg {
+    flex-shrink: 0;
   }
 `;
 
 const Footer: React.FC = () => {
   return (
     <FooterContainer id="footer">
-      <p className="footer">&copy;2026 N-i-ke All Right Reserved.</p>
+      <a
+        href={REPO_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="github-link cursor-target"
+        aria-label="View source on GitHub"
+      >
+        <FaGithub size={18} aria-hidden="true" />
+        <span>View on GitHub</span>
+      </a>
+      <p className="footer-copy">&copy;2026 N-i-ke All Right Reserved.</p>
     </FooterContainer>
   );
 };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -62,6 +62,10 @@ const RightCluster = styled.div`
   align-items: center;
   gap: 12px;
   min-width: 0;
+
+  @media screen and (max-width: 480px) {
+    gap: 8px;
+  }
 `;
 
 const GitHubIconLink = styled.a`
@@ -76,6 +80,7 @@ const GitHubIconLink = styled.a`
   background-color: rgba(0, 0, 0, 0.25);
   text-decoration: none;
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  flex-shrink: 0;
 
   &:hover {
     color: #00d8ff;
@@ -88,6 +93,11 @@ const GitHubIconLink = styled.a`
   &:focus-visible {
     outline: 2px solid #00d8ff;
     outline-offset: 2px;
+  }
+
+  @media screen and (max-width: 374px) {
+    width: 32px;
+    height: 32px;
   }
 `;
 
@@ -390,6 +400,15 @@ const Header: React.FC = () => {
         </Brand>
         <RightCluster>
           <LangToggle locale={locale} onChange={setLocale} />
+          <GitHubIconLink
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-target"
+            aria-label="View source on GitHub"
+          >
+            <FaGithub size={18} aria-hidden="true" />
+          </GitHubIconLink>
           <MenuButton
             type="button"
             className={isOpen ? "open" : ""}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { FaGithub } from "react-icons/fa";
 import GooeyNav from "../GooeyNav";
 import { useLocale, type Locale } from "../../contexts/LocaleContext";
 import "./Header.css";
+
+const REPO_URL = "https://github.com/N-i-ke/self-introduction";
 
 const HeaderContainer = styled.header`
   text-align: center;
@@ -59,6 +62,33 @@ const RightCluster = styled.div`
   align-items: center;
   gap: 12px;
   min-width: 0;
+`;
+
+const GitHubIconLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 216, 255, 0.45);
+  color: #cfeaff;
+  background-color: rgba(0, 0, 0, 0.25);
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    color: #00d8ff;
+    border-color: rgba(0, 216, 255, 0.85);
+    background-color: rgba(0, 216, 255, 0.12);
+    box-shadow: 0 0 12px rgba(0, 216, 255, 0.4);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #00d8ff;
+    outline-offset: 2px;
+  }
 `;
 
 const LangToggleWrapper = styled.div`
@@ -341,6 +371,15 @@ const Header: React.FC = () => {
         </NavCenter>
         <RightCluster>
           <LangToggle locale={locale} onChange={setLocale} />
+          <GitHubIconLink
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-target"
+            aria-label="View source on GitHub"
+          >
+            <FaGithub size={18} aria-hidden="true" />
+          </GitHubIconLink>
         </RightCluster>
       </Bar>
 


### PR DESCRIPTION
Closes #67

## 概要
サイトから GitHub リポジトリに飛べる導線を Header (desktop) と Footer の 2 箇所に追加。閲覧者がソースコードを直接確認しやすくする。

## 変更内容

### Header (desktop bar)
- `src/components/Header/Header.tsx` に `GitHubIconLink` (styled.a) を新設
- desktop bar の `RightCluster` 内、`LangToggle` の右側に配置
- 36×36 円形のアイコンボタン、cyan アウトライン + hover で点灯（border / shadow / 軽い上方トランスフォーム）
- `cursor-target` で TargetCursor のロックオン対象に
- `target=_blank` + `rel=noopener noreferrer` / `aria-label="View source on GitHub"` / `focus-visible`
- **mobile bar には追加しない**: 既に Brand + LangToggle + ハンバーガーで詰まっており、SP では Footer の GitHub ボタンで動線を担保

### Footer
- `src/components/Footer/Footer.tsx` を改修
- `react-icons/fa` の `FaGithub` を使った pill 形状ボタン（cyan アウトライン）
- `cursor-target` / `target=_blank` / a11y 一式
- Footer 全体を column flex に再構成し、GitHub ボタン + 著作権テキストの縦並び

### README
- main 側で既に削除されている GA Measurement ID 行を本ブランチからも除去（merge conflict 回避）

## 検証
- [x] `yarn typecheck` → エラーなし
- [x] `yarn build` → 成功
- [ ] ブラウザ目視:
  - [ ] Header (PC) 右端に GitHub アイコンが見える
  - [ ] Footer に "View on GitHub" ボタンが見える
  - [ ] 両方ともクリックで別タブにリポジトリが開く
  - [ ] hover / focus / TargetCursor 演出が機能する
  - [ ] PC / SP どちらでもレイアウト破綻なし

## アウトオブスコープ
- mobile bar への GitHub アイコン追加
- SNS / X / Note 等の他リンク
- リポジトリ stats / star count の表示