### PR TITLE
fix: Favicon の SVG を簡素化 + URL に ?v=2 でキャッシュバスト

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
 
-    <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <!-- Favicon (v2 — ?v= で cache-bust) -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
+    <link rel="alternate icon" href="/favicon.ico?v=2" />
+    <link rel="apple-touch-icon" href="/favicon.svg?v=2" />
 
     <!-- Viewport / Theme -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,29 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0b0b0b" />
-      <stop offset="1" stop-color="#1a1a2a" />
-    </linearGradient>
-    <linearGradient id="stroke" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#00d8ff" />
-      <stop offset="1" stop-color="#7cff67" />
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="0.6" result="b" />
-      <feMerge>
-        <feMergeNode in="b" />
-        <feMergeNode in="SourceGraphic" />
-      </feMerge>
-    </filter>
-  </defs>
-  <rect width="32" height="32" rx="6" fill="url(#bg)" />
-  <path
-    d="M9 25 L9 7 L23 25 L23 7"
-    stroke="url(#stroke)"
-    stroke-width="3.4"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    fill="none"
-    filter="url(#glow)"
-  />
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0b0b0b"/>
+  <path d="M9 25 L9 7 L23 25 L23 7"
+        stroke="#00d8ff" stroke-width="4"
+        stroke-linecap="round" stroke-linejoin="round"
+        fill="none"/>
 </svg>


### PR DESCRIPTION
## 問題
シークレットウィンドウで開いても新しい favicon が反映されない。HTTP / Content-Type / HTML 参照は正しいことを確認済みだが、ブラウザのタブにアイコンが出ない。

## 原因（推定）
複雑な SVG（filter + 多色グラデ）は、ブラウザの favicon レンダラで描画が失敗するケースが知られている（特に Chrome / Safari）。

## 修正
1. **SVG の簡素化**
   - `filter` (`feGaussianBlur` + `feMerge`) を撤去
   - 背景・stroke 色をグラデから単色に変更（`#0b0b0b` / `#00d8ff`）
   - root `<svg>` に `width="32" height="32"` を明示
   - stroke-width を 3.4 → 4 にして小サイズでも視認性を確保

2. **キャッシュバスト**
   - `index.html` の favicon リンク 3 種類に `?v=2` を付与
   - 過去のキャッシュを確実にバイパスして新しい SVG を取得させる

## 検証
- [x] `yarn build` 成功
- [x] `docs/index.html` に `?v=2` 付き favicon リンクが反映
- [ ] マージ後、サイト再訪で N アイコンが見えること